### PR TITLE
fix(api): restricted 8 wi-fi profiles to amt profile

### DIFF
--- a/src/routes/admin/profiles/amtProfileValidator.ts
+++ b/src/routes/admin/profiles/amtProfileValidator.ts
@@ -4,7 +4,7 @@
  **********************************************************************/
 import { Request } from 'express'
 import { check, ValidationChain } from 'express-validator'
-import { ClientAction, ProfileWifiConfigs } from '../../../RCS.Config'
+import { ClientAction } from '../../../RCS.Config'
 
 export const amtProfileValidator = (): ValidationChain[] => {
   return [
@@ -102,14 +102,14 @@ export const amtProfileValidator = (): ValidationChain[] => {
         if (!req.body.dhcpEnabled && value?.length > 0) {
           throw new Error('Wifi supports only DHCP in AMT')
         }
-        const priorities = new Set(value.map((config: ProfileWifiConfigs) => {
+        if (value.length > 8) {
+          throw new Error('A maximum of 8 wifi profiles can be stored at a time.')
+        }
+        for (const config of value) {
+          // priority is uint8 on AMT, but api doesn't accept 0 because some profiles exists with O priority by default on some devices
           if (Number.isInteger(config.priority) && (config.priority < 1 || config.priority > 255)) {
             throw new Error('wifi config priority should be an integer and between 1 and 255')
           }
-          return config.priority
-        }))
-        if ([...priorities].length !== value.length) {
-          throw new Error('wifi config priority should be unique')
         }
         const wifiConfigs = await validatewifiConfigs(value, req as Request)
         if (wifiConfigs.length > 0) {
@@ -225,14 +225,13 @@ export const profileUpdateValidator = (): any => {
         } else if (!req.body.dhcpEnabled && value?.length > 0) {
           throw new Error('Wifi supports only DHCP in AMT')
         }
-        const priorities = new Set(value.map((config: ProfileWifiConfigs) => {
+        if (value.length > 8) {
+          throw new Error('A maximum of 8 wifi profiles can be stored at a time.')
+        }
+        for (const config of value) {
           if (Number.isInteger(config.priority) && (config.priority < 1 || config.priority > 255)) {
             throw new Error('wifi config priority should be an integer and between 1 and 255')
           }
-          return config.priority
-        }))
-        if ([...priorities].length !== value.length) {
-          throw new Error('wifi config priority should be unique')
         }
         const wifiConfigs = await validatewifiConfigs(value, req as Request)
         if (wifiConfigs.length > 0) {

--- a/src/test/collections/rps.postman_collection.json
+++ b/src/test/collections/rps.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "d2663acd-e2f9-4332-a522-5bb653697038",
+		"_postman_id": "847720d7-5e2e-46a0-95cd-9b3504e26370",
 		"name": "RPS API Tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -6067,62 +6067,6 @@
 							"response": []
 						},
 						{
-							"name": "Create AMT profile with duplicate priority for wifiConfig",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"Status code is 400\", function () {\r",
-											"    pm.response.to.have.status(400);\r",
-											"});\r",
-											"pm.test(\"Creation should fail\", function () {\r",
-											"    var result = pm.response.json();\r",
-											"    pm.expect(result.errors[0].msg).to.eql(\"wifi config priority should be unique\"),\r",
-											"    pm.expect(result.errors[0].param).to.eql(\"wifiConfigs\")\r",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json",
-										"type": "text"
-									},
-									{
-										"key": "X-RPS-API-Key",
-										"value": "APIKEYFORRPS123!",
-										"type": "text",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\r\n    \"profileName\": \"wifi-profile\",\r\n    \"amtPassword\": \"Intel123!\",\r\n    \"mebxPassword\": \"Intel123!\",\r\n    \"activation\": \"ccmactivate\",\r\n    \"tags\": [\"tag1\"],\r\n    \"dhcpEnabled\": true,\r\n    \"wifiConfigs\": [\r\n        {\r\n            \"priority\": 1,\r\n            \"profileName\": \"home2\"\r\n        },\r\n        {\r\n            \"priority\": 1,\r\n            \"profileName\": \"office\"\r\n        }\r\n    ]\r\n}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{host}}/api/v1/admin/profiles/",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{host}}"
-									],
-									"path": [
-										"api",
-										"v1",
-										"admin",
-										"profiles",
-										""
-									]
-								}
-							},
-							"response": []
-						},
-						{
 							"name": "Create AMT profile with DHCP enabled false and Wifi configs",
 							"event": [
 								{
@@ -6560,62 +6504,6 @@
 								"body": {
 									"mode": "raw",
 									"raw": "{\r\n    \"profileName\": \"wifi-profile\",\r\n    \"amtPassword\": \"Intel123!\",\r\n    \"mebxPassword\": \"Intel123!\",\r\n    \"activation\": \"ccmactivate\",\r\n    \"tags\": [\"tag1\"],\r\n    \"dhcpEnabled\": true,\r\n    \"wifiConfigs\": [\r\n        {\r\n            \"priority\": 1,\r\n            \"profileName\": \"home\"\r\n        },\r\n        {\r\n            \"priority\": 2,\r\n            \"profileName\": \"test\"\r\n        }\r\n    ]\r\n}"
-								},
-								"url": {
-									"raw": "{{protocol}}://{{host}}/api/v1/admin/profiles/",
-									"protocol": "{{protocol}}",
-									"host": [
-										"{{host}}"
-									],
-									"path": [
-										"api",
-										"v1",
-										"admin",
-										"profiles",
-										""
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Create AMT profile with duplicate priority for wifiConfig",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"Status code is 400\", function () {\r",
-											"    pm.response.to.have.status(400);\r",
-											"});\r",
-											"pm.test(\"Creation should fail\", function () {\r",
-											"    var result = pm.response.json();\r",
-											"    pm.expect(result.errors[0].msg).to.eql(\"wifi config priority should be unique\"),\r",
-											"    pm.expect(result.errors[0].param).to.eql(\"wifiConfigs\")\r",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "PATCH",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json",
-										"type": "text"
-									},
-									{
-										"key": "X-RPS-API-Key",
-										"value": "APIKEYFORRPS123!",
-										"type": "text",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\r\n    \"profileName\": \"wifi-profile\",\r\n    \"amtPassword\": \"Intel123!\",\r\n    \"mebxPassword\": \"Intel123!\",\r\n    \"activation\": \"ccmactivate\",\r\n    \"tags\": [\"tag1\"],\r\n    \"dhcpEnabled\": true,\r\n    \"wifiConfigs\": [\r\n        {\r\n            \"priority\": 1,\r\n            \"profileName\": \"home2\"\r\n        },\r\n        {\r\n            \"priority\": 1,\r\n            \"profileName\": \"office\"\r\n        }\r\n    ]\r\n}"
 								},
 								"url": {
 									"raw": "{{protocol}}://{{host}}/api/v1/admin/profiles/",


### PR DESCRIPTION
AB# 4016

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [X] API tests have been updated if applicable
- [X] All commented code has been removed
- [x] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.


## What are you changing?
Added a condition to check the maximum number of Wi Fi profiles added to AMT profile should not be more than 8 and removed a condition to check the uniqueness of Wi Fi profiles priority when they get added to AMT profiles. 

Enforcing uniqueness and prioritizing the Wi Fi profiles will be taken care at sample web UI. API is kept generic as expected by AMT. 

## Anything the reviewer should know when reviewing this PR?
Updated API postman tests. Scope to add few more and will open a new PR once its done. 

### If the there are associated PRs in other repositories, please link them here (i.e. open-amt-cloud-toolkit/repo#365 )
