### PR TITLE
refactor(randPass): removes '&' from server side random password gene…

### DIFF
--- a/src/test/passwordHelper.test.ts
+++ b/src/test/passwordHelper.test.ts
@@ -5,37 +5,43 @@
 
 import { PasswordHelper } from '../utils/PasswordHelper'
 
-test('check password length', () => {
+test('check password length 7', () => {
   const input: string = 'aB$1abc'
   const actual = PasswordHelper.passwordCheck(input)
   expect(actual).toBeFalsy()
 })
 
-test('check password length', () => {
+test('check password length 8', () => {
   const input: string = 'aB$1abcd'
   const actual = PasswordHelper.passwordCheck(input)
   expect(actual).toBeTruthy()
 })
 
-test('check password complexity', () => {
-  const input: string = 'aB11abcd'
-  const actual = PasswordHelper.passwordCheck(input)
-  expect(actual).toBeFalsy()
-})
-
-test('check password length', () => {
+test('check password length 33', () => {
   const input: string = 'aB$1abcdefghijklmnopqrstuvwxyz123'
   const actual = PasswordHelper.passwordCheck(input)
   expect(actual).toBeFalsy()
 })
 
-test('check password length', () => {
+test('check password length 32', () => {
   const input: string = 'aB$1abcdefghijklmnopqrstuvwxyz12'
   const actual = PasswordHelper.passwordCheck(input)
   expect(actual).toBeTruthy()
 })
 
-test('check password length', () => {
+test('check password generate length 20', () => {
   const actual = PasswordHelper.generateRandomPassword(20)
   expect(actual.length).toBe(20)
+})
+
+test('check password complexity weak', () => {
+  const input: string = 'aB11abcd'
+  const actual = PasswordHelper.passwordCheck(input)
+  expect(actual).toBeFalsy()
+})
+
+test('check password complexity bad symbol &', () => {
+  const input: string = 'aB&1abcd'
+  const actual = PasswordHelper.passwordCheck(input)
+  expect(actual).toBeFalsy()
 })

--- a/src/utils/PasswordHelper.ts
+++ b/src/utils/PasswordHelper.ts
@@ -28,7 +28,7 @@ const PasswordHelper = {
     const len: number = 8
     const maxLen: number = 32
     const matches: string[] = []
-    matches.push('[$@$!%*#?&]')
+    matches.push('[$@$!%*#?]')
     matches.push('[A-Z]')
     matches.push('[0-9]')
     matches.push('[a-z]')

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -5,7 +5,7 @@
 
 import { apiResponse } from '../models/RCS.Config'
 
-export const AMTRandomPasswordChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!@#$%^&*()'
+export const AMTRandomPasswordChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!@#$%^*()'
 export const AMTRandomPasswordLength = 16
 
 export const AppVersion = '1.2.0'

--- a/src/utils/passwordValidationUtils.ts
+++ b/src/utils/passwordValidationUtils.ts
@@ -1,3 +1,3 @@
 export const passwordLengthValidation = (value: string): boolean => value.length >= 8 && value.length <= 32
 
-export const passwordValidation = (value: string): boolean => /^(?=.*[0-9])(?=.*[!@#$%^&*])(?=.*[a-z])(?=.*[A-Z])[a-zA-Z0-9$@$!%*#?&-_~^]{8,32}$/.test(value)
+export const passwordValidation = (value: string): boolean => /^(?=.*[0-9])(?=.*[!@#$%^*])(?=.*[a-z])(?=.*[A-Z])[a-zA-Z0-9$@$!%*#?-_~^]{8,32}$/.test(value)


### PR DESCRIPTION
…ration

closes: [AB#4179](https://dev.azure.com/rbheBoards/c7d9d701-a85f-45ff-91f6-26c56ff2c4de/_workitems/edit/4179)

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ X] Unit Tests have been added for new changes
- [ X] API tests have been updated if applicable
- [X ] All commented code has been removed
- [X ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.


## What are you changing?

Removes the '&' character from server side random password generation.
Client side generation (profile-detail.component.ts) already avoids this character.


