### PR TITLE
fix: Update the AMT Domain Profile Name to only support letters, numbers, underscores and hyphens

### DIFF
--- a/src/routes/admin/domains/domain.test.ts
+++ b/src/routes/admin/domains/domain.test.ts
@@ -15,6 +15,108 @@ describe('Domain Profile Validation', () => {
   let pfxobj
   let value
 
+  describe('AMT Domain Profile Name Validation', () => {
+    test('should accept valid AMT Domain profile names with letters, numbers, underscores, and hyphens', () => {
+      const validProfileNames = [
+        'profile_name',
+        'profile-name',
+        'ProfileName123',
+        'my_profile_name',
+        'my-profile-name',
+        'profile123',
+        'PROFILE_NAME',
+        'PROFILE-NAME',
+        'test_123_profile',
+        'test-123-profile',
+        'a', // single character
+        'A', // single uppercase
+        '1', // single number
+        '_', // single underscore
+        '-', // single hyphen
+        'a_b-c_d-e', // mixed separators
+        'Test_Profile_123-ABC', // mixed case with numbers
+        '_start_with_underscore',
+        '-start-with-hyphen',
+        'end_with_underscore_',
+        'end-with-hyphen-',
+        '_profile-name_', // both start and end
+        '-profile_name-' // both start and end
+      ]
+
+      const profileNameRegex = /^[a-zA-Z0-9_-]+$/
+
+      validProfileNames.forEach((profileName) => {
+        expect(profileNameRegex.test(profileName)).toBe(true)
+      })
+    })
+
+    test('should reject AMT Domain profile names with invalid characters', () => {
+      const invalidProfileNames = [
+        'profile name', // contains space
+        'profile.name', // contains dot
+        'profile@name', // contains @
+        'profile!name', // contains !
+        'profile#name', // contains #
+        'profile$name', // contains $
+        'profile%name', // contains %
+        'profile^name', // contains ^
+        'profile&name', // contains &
+        'profile*name', // contains *
+        'profile(name)', // contains parentheses
+        'profile+name', // contains +
+        'profile=name', // contains =
+        'profile[name]', // contains brackets
+        'profile{name}', // contains braces
+        'profile|name', // contains pipe
+        'profile\\name', // contains backslash
+        'profile:name', // contains colon
+        'profile;name', // contains semicolon
+        'profile"name"', // contains quotes
+        "profile'name'", // contains single quotes
+        'profile<name>', // contains angle brackets
+        'profile,name', // contains comma
+        'profile?name', // contains question mark
+        'profile/name', // contains slash
+        'profile~name', // contains tilde
+        'profile`name', // contains backtick
+        ' profile', // leading space
+        'profile ', // trailing space
+        ' profile ', // leading and trailing spaces
+        '\tprofile', // tab character
+        'profile\n', // newline character
+        'profile\r', // carriage return
+        '' // empty string
+      ]
+
+      const profileNameRegex = /^[a-zA-Z0-9_-]+$/
+
+      invalidProfileNames.forEach((profileName) => {
+        expect(profileNameRegex.test(profileName)).toBe(false)
+      })
+    })
+
+    test('should handle edge cases for AMT Domain profile names', () => {
+      const profileNameRegex = /^[a-zA-Z0-9_-]+$/
+
+      // Test very long valid profile name
+      const longValidProfile = 'a'.repeat(50) + '-' + '_'.repeat(25) + '123'
+      expect(profileNameRegex.test(longValidProfile)).toBe(true)
+
+      // Test profile names with only separators
+      expect(profileNameRegex.test('___')).toBe(true)
+      expect(profileNameRegex.test('---')).toBe(true)
+      expect(profileNameRegex.test('_-_-_')).toBe(true)
+
+      // Test profile names with numbers only
+      expect(profileNameRegex.test('123456')).toBe(true)
+      expect(profileNameRegex.test('0')).toBe(true)
+
+      // Test mixed patterns
+      expect(profileNameRegex.test('_123-ABC_test')).toBe(true)
+      expect(profileNameRegex.test('profile_123-test_456')).toBe(true)
+    })
+  })
+
   test('passwordChecker - success', () => {
     req = {
       body: {

--- a/src/routes/admin/domains/domain.ts
+++ b/src/routes/admin/domains/domain.ts
@@ -18,8 +18,8 @@ export const domainInsertValidator = (): any => [
     .not()
     .isEmpty()
     .withMessage('AMT Domain profile name is required')
-    .matches('^[a-zA-Z0-9$@$!%*#?&-_~^]+$')
-    .withMessage('AMT Domain profile name accepts letters, numbers, special characters and no spaces'),
+    .matches('^[a-zA-Z0-9_-]+$')
+    .withMessage('AMT Domain profile name accepts letters, numbers, hyphens (-), and underscores (_)'),
   check('provisioningCertPassword')
     .not()
     .isEmpty()
@@ -46,8 +46,8 @@ export const domainUpdateValidator = (): any => [
     .not()
     .isEmpty()
     .withMessage('AMT Domain profile name is required')
-    .matches('^[a-zA-Z0-9$@$!%*#?&-_~^]+$')
-    .withMessage('AMT Domain name accepts letters, numbers, special characters and no spaces'),
+    .matches('^[a-zA-Z0-9_-]+$')
+    .withMessage('AMT Domain profile name accepts letters, numbers, hyphens (-), and underscores (_)'),
   check('domainSuffix'),
   check('provisioningCert'),
   check('provisioningCertStorageFormat')


### PR DESCRIPTION
…underscores and hyphens

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [x] Unit Tests have been added for new changes
- [x] API tests have been updated if applicable
- [x] All commented code has been removed
- [x] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?
- Update the AMT Domain name to support only numbers, letters, underscores and hyphens.
- Added unit test for the supported characters and also non support case

<!-- Please provide a short description of the updates that are in the PR -->
- This PR is to handle the issue:
         https://github.com/device-management-toolkit/cloud-deployment/issues/469
   The issue request is to update the AMT Domain name support to match the support in sample-UI which only support letters, numbers, underscores and hyphens.

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
