### PR TITLE
fix(activation): check upgrade result before reporting ACM activation…

### DIFF
--- a/src/stateMachines/activation.ts
+++ b/src/stateMachines/activation.ts
@@ -482,6 +482,9 @@ export class Activation {
       },
       isSHBCCMComplete: ({ context }) => context.shbcCCMComplete === true,
       isSHBCACMComplete: ({ context }) => context.shbcACMComplete === true,
+      isSHBCUpgradeSuccessful: ({ context }) =>
+        context.shbcCCMComplete === true &&
+        context.message.Envelope.Body?.UpgradeClientToAdmin_OUTPUT?.ReturnValue === 0,
       isCertExtracted: ({ context }) => context.certChainPfx != null,
       isValidCert: ({ context }) => devices[context.clientId].certObj != null,
       isDigestRealmInvalid: ({ context }) =>
@@ -926,7 +929,7 @@ export class Activation {
       CHECK_UPGRADE: {
         always: [
           {
-            guard: 'isSHBCCMComplete',
+            guard: 'isSHBCUpgradeSuccessful',
             actions: [
               ({ context }) => {
                 devices[context.clientId].status.Status = 'admin control mode.'


### PR DESCRIPTION
… success

The CHECK_UPGRADE state was only checking if the SHBC CCM phase completed, not whether the UpgradeClientToAdmin call actually succeeded. This caused false "activated in admin control mode" messages when ReturnValue was non-zero.

Added isSHBCUpgradeSuccessful guard that verifies both shbcCCMComplete and ReturnValue === 0 before proceeding with success actions.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
