### PR TITLE
fix: escape % in configName for secret manager paths to prevent 500

### DIFF
--- a/src/routes/admin/ciraconfig/create.test.ts
+++ b/src/routes/admin/ciraconfig/create.test.ts
@@ -41,4 +41,14 @@ describe('CIRA Config - Create', () => {
     expect(insertSpy).toHaveBeenCalledTimes(1)
     expect(resSpy.status).toHaveBeenCalledWith(500)
   })
+  it('should encode configName with special characters in secret path', async () => {
+    const writeSecretSpy = jest.fn<any>().mockResolvedValue({})
+    req.secretsManager = { writeSecretWithObject: writeSecretSpy }
+    req.body = { configName: '%fGLW#z_wqOD^LtX5vK1AXl', password: 'P@ssw0rd123' }
+    await createCiraConfig(req, resSpy)
+    expect(writeSecretSpy).toHaveBeenCalledWith('CIRAConfigs/%25fGLW%23z_wqOD^LtX5vK1AXl', {
+      MPS_PASSWORD: 'P@ssw0rd123'
+    })
+    expect(resSpy.status).toHaveBeenCalledWith(201)
+  })
 })

--- a/src/routes/admin/ciraconfig/create.ts
+++ b/src/routes/admin/ciraconfig/create.ts
@@ -21,7 +21,10 @@ export async function createCiraConfig(req: Request, res: Response): Promise<voi
       const secrets: CiraConfigSecrets = {
         MPS_PASSWORD: ciraConfig.password
       }
-      const secretRsp = await req.secretsManager.writeSecretWithObject(`CIRAConfigs/${ciraConfig.configName}`, secrets)
+      const secretRsp = await req.secretsManager.writeSecretWithObject(
+        `CIRAConfigs/${ciraConfig.configName.replace(/%/g, '%25').replace(/#/g, '%23')}`,
+        secrets
+      )
       if (secretRsp == null) {
         throw new Error('Error saving cira configuration secrets to secret provider')
       }

--- a/src/routes/admin/ciraconfig/delete.test.ts
+++ b/src/routes/admin/ciraconfig/delete.test.ts
@@ -45,4 +45,13 @@ describe('CIRA Config - delete', () => {
     expect(deleteSpy).toHaveBeenCalledWith('ciraConfig', req.tenantId)
     expect(resSpy.status).toHaveBeenCalledWith(500)
   })
+  it('should encode configName with special characters in secret path', async () => {
+    const deleteSecretSpy = jest.fn<any>().mockResolvedValue(true)
+    req.secretsManager = { deleteSecretAtPath: deleteSecretSpy }
+    req.params.ciraConfigName = '%fGLW#z_wqOD^LtX5vK1AXl'
+    spyOn(req.db.ciraConfigs, 'delete').mockResolvedValue(true)
+    await deleteCiraConfig(req, resSpy)
+    expect(deleteSecretSpy).toHaveBeenCalledWith('CIRAConfigs/%25fGLW%23z_wqOD^LtX5vK1AXl')
+    expect(resSpy.status).toHaveBeenCalledWith(204)
+  })
 })

--- a/src/routes/admin/ciraconfig/delete.ts
+++ b/src/routes/admin/ciraconfig/delete.ts
@@ -17,7 +17,9 @@ export async function deleteCiraConfig(req: Request, res: Response): Promise<voi
     const result: boolean = await req.db.ciraConfigs.delete(ciraConfigName, req.tenantId)
     if (result) {
       if (req.secretsManager) {
-        await req.secretsManager.deleteSecretAtPath(`CIRAConfigs/${ciraConfigName}`)
+        await req.secretsManager.deleteSecretAtPath(
+          `CIRAConfigs/${ciraConfigName.replace(/%/g, '%25').replace(/#/g, '%23')}`
+        )
       }
       MqttProvider.publishEvent('success', ['deleteCiraConfig'], `Deleted CIRA config : ${ciraConfigName}`)
       log.verbose(`Deleted CIRA config profile : ${ciraConfigName}`)

--- a/src/stateMachines/ciraConfiguration.test.ts
+++ b/src/stateMachines/ciraConfiguration.test.ts
@@ -347,4 +347,41 @@ describe('CIRA Configuration State Machine', () => {
       expect(loggerSpy).toHaveBeenCalled()
     })
   })
+
+  describe('getMPSPassword', () => {
+    beforeEach(() => {
+      machineContext.ciraConfig = ciraConfig
+    })
+
+    it('should escape % and # in configName when constructing secret path', async () => {
+      const getSecretAtPathSpy = jest.fn<any>().mockResolvedValue({ MPS_PASSWORD: 'secret' })
+      ciraStateMachineImpl.configurator = {
+        secretsManager: { getSecretAtPath: getSecretAtPathSpy }
+      } as any
+      machineContext.ciraConfig = { ...ciraConfig, configName: '%fGLW#z_wqOD^LtX5vK1AXl' }
+
+      await ciraStateMachineImpl.getMPSPassword({ input: machineContext })
+
+      expect(getSecretAtPathSpy).toHaveBeenCalledWith('CIRAConfigs/%25fGLW%23z_wqOD^LtX5vK1AXl')
+    })
+
+    it('should use configName as-is when no % present', async () => {
+      const getSecretAtPathSpy = jest.fn<any>().mockResolvedValue({ MPS_PASSWORD: 'secret' })
+      ciraStateMachineImpl.configurator = {
+        secretsManager: { getSecretAtPath: getSecretAtPathSpy }
+      } as any
+
+      await ciraStateMachineImpl.getMPSPassword({ input: machineContext })
+
+      expect(getSecretAtPathSpy).toHaveBeenCalledWith('CIRAConfigs/config1')
+    })
+
+    it('should throw error when configName is missing', async () => {
+      machineContext.ciraConfig = null
+
+      await expect(ciraStateMachineImpl.getMPSPassword({ input: machineContext })).rejects.toThrow(
+        'CIRA configuration name is required to retrieve MPS password from secret provider'
+      )
+    })
+  })
 })

--- a/src/stateMachines/ciraConfiguration.ts
+++ b/src/stateMachines/ciraConfiguration.ts
@@ -73,7 +73,13 @@ export class CIRAConfiguration {
   }
 
   getMPSPassword = async ({ input }: { input: CIRAConfigContext }): Promise<any> => {
-    const data = await this.configurator.secretsManager.getSecretAtPath(`CIRAConfigs/${input.ciraConfig?.configName}`)
+    const configName = input.ciraConfig?.configName
+    if (!configName) {
+      throw new globalThis.Error('CIRA configuration name is required to retrieve MPS password from secret provider')
+    }
+    const data = await this.configurator.secretsManager.getSecretAtPath(
+      `CIRAConfigs/${configName.replace(/%/g, '%25').replace(/#/g, '%23')}`
+    )
     return data
   }
 


### PR DESCRIPTION
* The % in configName is misinterpreted as a URL-encoded sequence in the secret manager path, causing an unhandled exception.
* Escape % as %25 in configName when constructing secret manager paths in create, delete, and read operations.
* Add null guard for configName in getMPSPassword.

Resolves #2599

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
