### PR TITLE
docs: replace Azure Boards / JIRA refs with GitHub issues

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -18,7 +18,7 @@ The **header** with **type** is mandatory. The **scope** of the header is option
 
 Any line of the commit message should no be longer 72 characters! This allows the message to be easier to read on GitHub as well as in various git tools.
 
-The footer should contain a reference to an Azure Boards ticket (e.g. AB#[number]).
+The footer should contain a reference to a GitHub issue (e.g. `#1234`) using the [GitHub closing-keyword syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) so the issue auto-closes when the PR merges.
 
 Example 1:
 
@@ -28,7 +28,7 @@ feat(telemetry): Add new MQTT events
 Events are now emitted over various /mps topics on MQTT for success/failures
 as they occur throughout the service.
 
-Resolves: AB#2222
+Closes: #1234
 ```
 
 ### Revert
@@ -101,7 +101,7 @@ Further paragraphs come after blank lines.
 
 ### Footer
 
-The footer should contain a reference to JIRA ticket (e.g. SL6-0000) that this commit **Closes** or **Resolves**.
+The footer should contain a reference to the GitHub issue this commit **Closes**, **Fixes**, or **Resolves** (e.g. `Closes: #1234`). See [GitHub's closing-keyword syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for the keywords that trigger auto-close on merge.
 The footer should contain any information about **Breaking Changes**.
 
 **Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines.


### PR DESCRIPTION
CONTRIBUTING.MD instructed contributors to put `AB#<n>` (Azure Boards) in the footer and, lower in the same doc, a JIRA `SL6-` ticket. Neither tracker is current — this project tracks work in GitHub issues. Update both spots to use GitHub's closing-keyword syntax (`Closes: #1234`) so referenced issues auto-close on merge.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
