### PR TITLE
feat: allow profile PATCH without passwords

### DIFF
--- a/src/interfaces/ISecretManagerService.ts
+++ b/src/interfaces/ISecretManagerService.ts
@@ -37,6 +37,7 @@ export interface CertCredentials {
 
 export interface ISecretManagerService {
   getSecretFromKey: (path: string, key: string) => Promise<string | null>
+  // null only when the secret is absent (404); transport/server errors throw.
   getSecretAtPath: (
     path: string
   ) => Promise<DeviceCredentials | WifiCredentials | TLSCredentials | CertCredentials | CiraConfigSecrets | null>

--- a/src/routes/admin/profiles/amtProfileValidator.test.ts
+++ b/src/routes/admin/profiles/amtProfileValidator.test.ts
@@ -74,6 +74,18 @@ describe('AMT Profile Validation', () => {
       expect(errMap.tlsMode).toBeTruthy()
       expect(errMap.tlsSigningAuthority).toBeTruthy()
     })
+    it('should fail on creation when amtPassword is omitted and generateRandomPassword is false', async () => {
+      delete req.body.amtPassword
+      await testExpressValidatorMiddleware(req, res, amtProfileValidator())
+      const errors = validationResult(req)
+      expect(errors.mapped().generateRandomPassword).toBeTruthy()
+    })
+    it('should fail on creation in ACM when mebxPassword is omitted and generateRandomMEBxPassword is false', async () => {
+      delete req.body.mebxPassword
+      await testExpressValidatorMiddleware(req, res, amtProfileValidator())
+      const errors = validationResult(req)
+      expect(errors.mapped().generateRandomMEBxPassword).toBeTruthy()
+    })
   })
   describe('Update', () => {
     it('should pass on update happy path', async () => {
@@ -96,6 +108,39 @@ describe('AMT Profile Validation', () => {
       const errMap = errors.mapped()
       expect(errMap.tlsMode).toBeTruthy()
       expect(errMap.tlsSigningAuthority).toBeTruthy()
+    })
+    it('should pass on update when amtPassword and mebxPassword are omitted', async () => {
+      delete req.body.amtPassword
+      delete req.body.mebxPassword
+      await testExpressValidatorMiddleware(req, res, profileUpdateValidator())
+      const errors = validationResult(req)
+      expect(errors.isEmpty()).toBeTruthy()
+    })
+    it('should fail on update when an invalid amtPassword is provided', async () => {
+      req.body.amtPassword = 'weak'
+      await testExpressValidatorMiddleware(req, res, profileUpdateValidator())
+      const errors = validationResult(req)
+      expect(errors.mapped().amtPassword).toBeTruthy()
+    })
+    it('should fail on update when an invalid mebxPassword is provided', async () => {
+      req.body.mebxPassword = 'weak'
+      await testExpressValidatorMiddleware(req, res, profileUpdateValidator())
+      const errors = validationResult(req)
+      expect(errors.mapped().mebxPassword).toBeTruthy()
+    })
+    it('should pass on update when amtPassword and mebxPassword are explicitly null', async () => {
+      req.body.amtPassword = null
+      req.body.mebxPassword = null
+      await testExpressValidatorMiddleware(req, res, profileUpdateValidator())
+      const errors = validationResult(req)
+      expect(errors.isEmpty()).toBeTruthy()
+    })
+    it('should fail on update when generateRandomPassword is true and amtPassword is also provided', async () => {
+      req.body.generateRandomPassword = true
+      req.body.amtPassword = 'ABCabc123!@#'
+      await testExpressValidatorMiddleware(req, res, profileUpdateValidator())
+      const errors = validationResult(req)
+      expect(errors.mapped().generateRandomPassword).toBeTruthy()
     })
   })
 })

--- a/src/routes/admin/profiles/amtProfileValidator.ts
+++ b/src/routes/admin/profiles/amtProfileValidator.ts
@@ -237,25 +237,9 @@ export const profileUpdateValidator = (): any => [
     .isIn(Object.values(ClientAction))
     .withMessage(
       `Activation accepts either ${ClientAction.ADMINCTLMODE} (admin control activation) or ${ClientAction.CLIENTCTLMODE} (client control mode activation)`
-    )
-    .custom((value, { req }) => {
-      const pwd = req.body.amtPassword
-      const randomPwd = req.body.generateRandomPassword
-      if (pwd == null && !randomPwd) {
-        throw new Error('Either generateRandomPassword should be enabled or provide amtPassword')
-      }
-      const mebxPwd = req.body.mebxPassword
-      const mebxRandomPwd = req.body.generateRandomMEBxPassword
-      if (value === ClientAction.ADMINCTLMODE) {
-        if (mebxPwd == null && !mebxRandomPwd) {
-          throw new Error(`MEBx Password is required for ${ClientAction.ADMINCTLMODE}`)
-        }
-      }
-      return true
-    }),
+    ),
   check('amtPassword')
-    .if((value, { req }) => req.body.generateRandomPassword === false)
-    .optional()
+    .optional({ nullable: true })
     .matches('^(?=.*[0-9])(?=.*[!@#$%^&*])(?=.*[a-z])(?=.*[A-Z])[a-zA-Z0-9$@$!%*#?&-_~^]{8,32}$')
     .withMessage(
       'AMT password is required field should contains at least one lowercase letter, one uppercase letter, one numeric digit,and one special character and password length should be in between 8 to 32.'
@@ -266,21 +250,14 @@ export const profileUpdateValidator = (): any => [
     .withMessage('Generate random AMT password must be a boolean true or false')
     .custom((value, { req }) => {
       const pwd = req.body.amtPassword
-      if (value === true) {
-        if (pwd != null) {
-          throw new Error(
-            'Either generate Random AMT Password should be enabled or should provide AMT Password but not both'
-          )
-        }
-      } else {
-        if (pwd == null) {
-          throw new Error('If generate random AMT password is disabled, amtPassword is mandatory')
-        }
+      if (value === true && pwd != null) {
+        throw new Error(
+          'Either generate Random AMT Password should be enabled or should provide AMT Password but not both'
+        )
       }
       return true
     }),
   check('mebxPassword')
-    .if((value, { req }) => req.body.generateRandomMEBxPassword === false)
     .optional({ nullable: true })
     .matches('^(?=.*[0-9])(?=.*[!@#$%^&*])(?=.*[a-z])(?=.*[A-Z])[a-zA-Z0-9$@$!%*#?&-_~^]{8,32}$')
     .withMessage(
@@ -293,18 +270,8 @@ export const profileUpdateValidator = (): any => [
     .custom((value, { req }) => {
       const pwd = req.body.mebxPassword
       const activationMode = req.body.activation
-      if (activationMode === ClientAction.ADMINCTLMODE) {
-        if (value === true) {
-          if (pwd != null) {
-            throw new Error(
-              'Either generate MEBx password should be enabled or should provide MEBx password, but not both'
-            )
-          }
-        } else {
-          if (pwd == null) {
-            throw new Error('If generate random MEBx password is disabled, mebxPassword is mandatory')
-          }
-        }
+      if (activationMode === ClientAction.ADMINCTLMODE && value === true && pwd != null) {
+        throw new Error('Either generate MEBx password should be enabled or should provide MEBx password, but not both')
       }
       return true
     }),

--- a/src/routes/admin/profiles/edit.test.ts
+++ b/src/routes/admin/profiles/edit.test.ts
@@ -208,6 +208,161 @@ describe('AMT Profile - Edit', () => {
     expect(resSpy.json).toHaveBeenCalledWith(amtConfig)
     expect(writeSecretWithObjectSpy).toHaveBeenCalledTimes(1)
   })
+  it('should refuse update and not touch vault when stored credentials are unreadable', async () => {
+    req.secretsManager = {
+      writeSecretWithObject: vi.fn(),
+      getSecretAtPath: vi.fn(),
+      deleteSecretAtPath: vi.fn()
+    }
+    const getSecretAtPathSpy = vi.spyOn(req.secretsManager, 'getSecretAtPath').mockResolvedValue(null)
+    const writeSpy = vi.spyOn(req.secretsManager, 'writeSecretWithObject')
+    const deleteSpy = vi.spyOn(req.secretsManager, 'deleteSecretAtPath')
+    const updateSpy = vi.spyOn(req.db.profiles, 'update')
+    req.body = {
+      profileName: 'static',
+      activation: ClientAction.ADMINCTLMODE,
+      generateRandomPassword: false,
+      generateRandomMEBxPassword: false,
+      version: '1'
+    }
+    vi.spyOn(req.db.profiles, 'getByName').mockResolvedValue({
+      profileName: 'static',
+      activation: ClientAction.ADMINCTLMODE,
+      generateRandomPassword: false,
+      generateRandomMEBxPassword: false,
+      version: '1'
+    })
+    await editProfile(req, resSpy)
+    expect(getSecretAtPathSpy).toHaveBeenCalledWith('profiles/static')
+    expect(updateSpy).not.toHaveBeenCalled()
+    expect(deleteSpy).not.toHaveBeenCalled()
+    expect(writeSpy).not.toHaveBeenCalled()
+    expect(resSpy.status).not.toHaveBeenCalledWith(200)
+  })
+  it('should refuse update when the stored secret is missing a required password field', async () => {
+    req.secretsManager = {
+      writeSecretWithObject: vi.fn(),
+      getSecretAtPath: vi.fn(),
+      deleteSecretAtPath: vi.fn()
+    }
+    const getSecretAtPathSpy = vi
+      .spyOn(req.secretsManager, 'getSecretAtPath')
+      .mockResolvedValue({ AMT_PASSWORD: 'RealP@ssw0rd' })
+    const writeSpy = vi.spyOn(req.secretsManager, 'writeSecretWithObject')
+    const updateSpy = vi.spyOn(req.db.profiles, 'update')
+    req.body = {
+      profileName: 'static',
+      activation: ClientAction.ADMINCTLMODE,
+      generateRandomPassword: false,
+      generateRandomMEBxPassword: false,
+      version: '1'
+    }
+    vi.spyOn(req.db.profiles, 'getByName').mockResolvedValue({
+      profileName: 'static',
+      activation: ClientAction.ADMINCTLMODE,
+      generateRandomPassword: false,
+      generateRandomMEBxPassword: false,
+      version: '1'
+    })
+    await editProfile(req, resSpy)
+    expect(getSecretAtPathSpy).toHaveBeenCalledWith('profiles/static')
+    expect(updateSpy).not.toHaveBeenCalled()
+    expect(writeSpy).not.toHaveBeenCalled()
+    expect(resSpy.status).not.toHaveBeenCalledWith(200)
+  })
+  it('should reject switching to ACM without a MEBx password available', async () => {
+    // CCM->ACM with no MEBx (none stored, not random) must be rejected, not stored empty.
+    req.secretsManager = {
+      writeSecretWithObject: vi.fn(),
+      getSecretAtPath: vi.fn(),
+      deleteSecretAtPath: vi.fn()
+    }
+    const getSecretAtPathSpy = vi.spyOn(req.secretsManager, 'getSecretAtPath')
+    const updateSpy = vi.spyOn(req.db.profiles, 'update')
+    req.body = {
+      profileName: 'wasCCM',
+      activation: ClientAction.ADMINCTLMODE,
+      generateRandomPassword: false,
+      generateRandomMEBxPassword: false,
+      version: '1'
+    }
+    vi.spyOn(req.db.profiles, 'getByName').mockResolvedValue({
+      profileName: 'wasCCM',
+      activation: ClientAction.CLIENTCTLMODE,
+      generateRandomPassword: false,
+      generateRandomMEBxPassword: false,
+      version: '1'
+    })
+    await editProfile(req, resSpy)
+    expect(getSecretAtPathSpy).not.toHaveBeenCalled()
+    expect(updateSpy).not.toHaveBeenCalled()
+    expect(resSpy.status).not.toHaveBeenCalledWith(200)
+  })
+  it('should not read or refuse on Vault when a CCM/random-password profile is edited without passwords', async () => {
+    // Regression: field-only PATCH on a random/CCM profile must not read-and-refuse on null Vault.
+    req.secretsManager = {
+      writeSecretWithObject: vi.fn(),
+      getSecretAtPath: vi.fn(),
+      deleteSecretAtPath: vi.fn()
+    }
+    const getSecretAtPathSpy = vi.spyOn(req.secretsManager, 'getSecretAtPath').mockResolvedValue(null)
+    vi.spyOn(req.secretsManager, 'writeSecretWithObject').mockResolvedValue({})
+    vi.spyOn(req.secretsManager, 'deleteSecretAtPath').mockResolvedValue(null)
+    req.body = {
+      profileName: 'random',
+      activation: ClientAction.CLIENTCTLMODE,
+      tags: ['tag123'],
+      generateRandomPassword: false,
+      generateRandomMEBxPassword: false,
+      version: '1'
+    }
+    vi.spyOn(req.db.profiles, 'getByName').mockResolvedValue({
+      profileName: 'random',
+      activation: ClientAction.CLIENTCTLMODE,
+      amtPassword: null,
+      mebxPassword: null,
+      generateRandomPassword: true,
+      generateRandomMEBxPassword: true,
+      version: '1'
+    })
+    vi.spyOn(req.db.profiles, 'update').mockResolvedValue({ profileName: 'random', version: '2' })
+    await editProfile(req, resSpy)
+    expect(getSecretAtPathSpy).not.toHaveBeenCalled()
+    expect(resSpy.status).toHaveBeenCalledWith(200)
+  })
+  it('should preserve stored static passwords when PATCH omits them', async () => {
+    req.secretsManager = {
+      writeSecretWithObject: vi.fn(),
+      getSecretAtPath: vi.fn(),
+      deleteSecretAtPath: vi.fn()
+    }
+    const getSecretAtPathSpy = vi
+      .spyOn(req.secretsManager, 'getSecretAtPath')
+      .mockResolvedValue({ AMT_PASSWORD: 'RealP@ssw0rd', MEBX_PASSWORD: 'RealM3bx!42' })
+    const writeSpy = vi.spyOn(req.secretsManager, 'writeSecretWithObject').mockResolvedValue({})
+    req.body = {
+      profileName: 'static',
+      activation: ClientAction.ADMINCTLMODE,
+      generateRandomPassword: false,
+      generateRandomMEBxPassword: false,
+      version: '1'
+    }
+    vi.spyOn(req.db.profiles, 'getByName').mockResolvedValue({
+      profileName: 'static',
+      activation: ClientAction.ADMINCTLMODE,
+      generateRandomPassword: false,
+      generateRandomMEBxPassword: false,
+      version: '1'
+    })
+    vi.spyOn(req.db.profiles, 'update').mockResolvedValue({ profileName: 'static', version: '2' })
+    await editProfile(req, resSpy)
+    expect(getSecretAtPathSpy).toHaveBeenCalledWith('profiles/static')
+    expect(writeSpy).toHaveBeenCalledWith('profiles/static', {
+      AMT_PASSWORD: 'RealP@ssw0rd',
+      MEBX_PASSWORD: 'RealM3bx!42'
+    })
+    expect(resSpy.status).toHaveBeenCalledWith(200)
+  })
 })
 
 test('test handleAMTpassword when the request body amtPassword is null or undefined', () => {

--- a/src/routes/admin/profiles/edit.ts
+++ b/src/routes/admin/profiles/edit.ts
@@ -4,7 +4,7 @@
  **********************************************************************/
 
 import Logger from '../../../Logger.js'
-import { NOT_FOUND_EXCEPTION, NOT_FOUND_MESSAGE } from '../../../utils/constants.js'
+import { API_UNEXPECTED_EXCEPTION, NOT_FOUND_EXCEPTION, NOT_FOUND_MESSAGE } from '../../../utils/constants.js'
 import { type AMTConfiguration } from '../../../models/index.js'
 import {
   ClientAction,
@@ -35,8 +35,61 @@ export async function editProfile(req: Request, res: Response): Promise<void> {
       amtConfig.wifiConfigs = await handleWifiConfigs(newConfig, oldConfig, req.db.profileWirelessConfigs)
       amtConfig.proxyConfigs = await handleProxyConfigs(newConfig, oldConfig, req.db.profileProxyConfigs)
       // Assigning value key value for AMT Random Password and MEBx Random Password to store in database
-      const amtPwdBefore = amtConfig.amtPassword ?? ''
-      const mebxPwdBefore = amtConfig.mebxPassword ?? ''
+      let amtPwdBefore = amtConfig.amtPassword ?? ''
+      let mebxPwdBefore = amtConfig.mebxPassword ?? ''
+      const hasStoredAmtSecret = oldConfig.generateRandomPassword === false
+      const hasStoredMebxSecret =
+        oldConfig.generateRandomMEBxPassword === false && oldConfig.activation === ClientAction.ADMINCTLMODE
+      // ACM needs a MEBx: provided, random, or already stored.
+      if (
+        amtConfig.activation === ClientAction.ADMINCTLMODE &&
+        !amtConfig.generateRandomMEBxPassword &&
+        newConfig.mebxPassword == null &&
+        !hasStoredMebxSecret
+      ) {
+        throw new RPSError(`MEBx password is required for ${ClientAction.ADMINCTLMODE}`)
+      }
+      // Password omitted: preserve the stored one, but only if the old profile had it.
+      const needsStoredAmt = newConfig.amtPassword == null && !amtConfig.generateRandomPassword && hasStoredAmtSecret
+      const needsStoredMebx =
+        newConfig.mebxPassword == null &&
+        !amtConfig.generateRandomMEBxPassword &&
+        hasStoredMebxSecret &&
+        amtConfig.activation === ClientAction.ADMINCTLMODE
+      if (req.secretsManager && (needsStoredAmt || needsStoredMebx)) {
+        const stored = (await req.secretsManager.getSecretAtPath(
+          `profiles/${oldConfig.profileName}`
+        )) as DeviceCredentials | null
+        // null = secret genuinely absent (errors already threw). Refuse rather than
+        // write the DB placeholder literal over the real password.
+        if (stored == null) {
+          throw new RPSError(
+            API_UNEXPECTED_EXCEPTION(
+              `reading stored credentials for profile ${oldConfig.profileName}; refusing to overwrite secret with placeholder`
+            )
+          )
+        }
+        if (needsStoredAmt) {
+          if (stored.AMT_PASSWORD == null) {
+            throw new RPSError(
+              API_UNEXPECTED_EXCEPTION(
+                `stored credentials for profile ${oldConfig.profileName} are missing AMT_PASSWORD; refusing to overwrite secret with placeholder`
+              )
+            )
+          }
+          amtPwdBefore = stored.AMT_PASSWORD
+        }
+        if (needsStoredMebx) {
+          if (stored.MEBX_PASSWORD == null) {
+            throw new RPSError(
+              API_UNEXPECTED_EXCEPTION(
+                `stored credentials for profile ${oldConfig.profileName} are missing MEBX_PASSWORD; refusing to overwrite secret with placeholder`
+              )
+            )
+          }
+          mebxPwdBefore = stored.MEBX_PASSWORD
+        }
+      }
       if (req.secretsManager) {
         // store the AMT password key into db
         if (!amtConfig.generateRandomPassword) {

--- a/src/secrets/vault/index.test.ts
+++ b/src/secrets/vault/index.test.ts
@@ -9,8 +9,16 @@ import { type ILogger } from '../../interfaces/ILogger.js'
 import { config } from '../../test/helper/Config.js'
 import { Environment } from '../../utils/Environment.js'
 import { type DeviceCredentials } from '../../interfaces/ISecretManagerService.js'
+import { HTTPError } from 'got'
 
 import { vi, type MockInstance } from 'vitest'
+
+const makeHttpError = (statusCode: number): HTTPError => {
+  const err = Object.create(HTTPError.prototype) as HTTPError & { response: any; message: string }
+  err.response = { statusCode }
+  err.message = `Response code ${statusCode}`
+  return err
+}
 let secretManagerService: VaultService = null as any
 Environment.Config = config
 let gotSpy: MockInstance
@@ -71,14 +79,38 @@ it('should get a secret from a specific given path', async () => {
   expect(gotSpy).toHaveBeenCalledWith(secretPath)
 })
 
-it('should throw an exception and return null if given path does not exist', async () => {
-  gotFailSpy = vi.spyOn(secretManagerService.gotClient, 'get')
-  gotFailSpy.mockResolvedValue({
-    json: vi.fn(async () => await Promise.reject(new Error('Not Found')))
-  })
+it('should return null when Vault responds 404 (secret genuinely absent)', async () => {
+  gotFailSpy = vi.spyOn(secretManagerService.gotClient, 'get').mockImplementation(
+    () =>
+      ({
+        json: vi.fn(async () => await Promise.reject(makeHttpError(404)))
+      }) as any
+  )
   const result = await secretManagerService.getSecretAtPath('does/not/exist')
   expect(result).toEqual(null)
   expect(gotFailSpy).toHaveBeenCalledWith('does/not/exist')
+})
+
+it('should throw when Vault responds with a server error (5xx)', async () => {
+  gotFailSpy = vi.spyOn(secretManagerService.gotClient, 'get').mockImplementation(
+    () =>
+      ({
+        json: vi.fn(async () => await Promise.reject(makeHttpError(503)))
+      }) as any
+  )
+  await expect(secretManagerService.getSecretAtPath('transient/failure')).rejects.toMatchObject({
+    response: { statusCode: 503 }
+  })
+})
+
+it('should throw on network/transport errors', async () => {
+  gotFailSpy = vi.spyOn(secretManagerService.gotClient, 'get').mockImplementation(
+    () =>
+      ({
+        json: vi.fn(async () => await Promise.reject(new Error('ECONNRESET')))
+      }) as any
+  )
+  await expect(secretManagerService.getSecretAtPath('any/path')).rejects.toThrow('ECONNRESET')
 })
 
 it('should create a secret', async () => {

--- a/src/secrets/vault/index.ts
+++ b/src/secrets/vault/index.ts
@@ -12,7 +12,7 @@ import {
 } from '../../interfaces/ISecretManagerService.js'
 import { type ILogger } from '../../interfaces/ILogger.js'
 import { Environment } from '../../utils/Environment.js'
-import got, { type Got } from 'got'
+import got, { HTTPError, type Got } from 'got'
 
 export class VaultService implements ISecretManagerService {
   gotClient: Got
@@ -53,9 +53,15 @@ export class VaultService implements ISecretManagerService {
       secretData.version = rspJson.data.metadata.version
       return secretData
     } catch (error) {
+      // 404 means the secret is absent; other errors throw so a Vault hiccup
+      // isn't mistaken for "no secret".
+      if (error instanceof HTTPError && error.response?.statusCode === 404) {
+        this.logger.debug(`secret not found at path: ${path}`)
+        return null
+      }
       this.logger.error('getSecretAtPath error \r\n')
       this.logger.error(error)
-      return null
+      throw error
     }
   }
 

--- a/src/test/collections/rps.postman_collection.json
+++ b/src/test/collections/rps.postman_collection.json
@@ -5792,21 +5792,22 @@
           "response": []
         },
         {
-          "name": "Update Profile \"profile6\" ccmactivate with password combo false:missing",
+          "name": "Update Profile \"profile6\" ccmactivate succeeds without passwords",
           "event": [
             {
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test(\"Status code is 400\", function () {\r",
-                  "    pm.response.to.have.status(400);\r",
+                  "var responseBody = pm.response.json();\r",
+                  "pm.globals.set(\"profile6Version\", responseBody.version);\r",
+                  "\r",
+                  "pm.test(\"Status code is 200\", function () {\r",
+                  "    pm.response.to.have.status(200);\r",
                   "});\r",
                   "\r",
-                  "pm.test(\"Request fail\", function () {\r",
-                  "     var result = pm.response.json();\r",
-                  "    pm.expect(result.errors[0].msg).to.eql(\"Either generateRandomPassword should be enabled or provide amtPassword\")\r",
-                  "    pm.expect(result.errors[0].path).to.eql(\"activation\")\r",
-                  "    pm.expect(result.errors[0].location).to.eql(\"body\")\r",
+                  "pm.test(\"PATCH succeeds when passwords are omitted\", function () {\r",
+                  "    pm.expect(responseBody.profileName).to.eql(\"profile6\")\r",
+                  "    pm.expect(responseBody.activation).to.eql(\"ccmactivate\")\r",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -6202,24 +6203,19 @@
           "response": []
         },
         {
-          "name": "Update Profile \"profile6\" activation to acmactivate without mebx password",
+          "name": "Update Profile \"profile6\" activation to acmactivate without mebx password is rejected",
           "event": [
             {
               "listen": "test",
               "script": {
                 "exec": [
+                  "var responseBody = pm.response.json();\r",
+                  "\r",
                   "pm.test(\"Status code is 400\", function () {\r",
                   "    pm.response.to.have.status(400);\r",
                   "});\r",
-                  "pm.test(\"Creation should fail when payload contains acmactivate without mebx password\", function () {\r",
-                  "    var result = pm.response.json();\r",
-                  "    pm.expect(result.errors[0].msg).to.eql(\"Either generateRandomPassword should be enabled or provide amtPassword\")\r",
-                  "    pm.expect(result.errors[0].path).to.eql(\"activation\")\r",
-                  "    pm.expect(result.errors[0].location).to.eql(\"body\")\r",
-                  "\r",
-                  "    pm.expect(result.errors[1].msg).to.eql(\"If generate random AMT password is disabled, amtPassword is mandatory\")\r",
-                  "    pm.expect(result.errors[1].path).to.eql(\"generateRandomPassword\")\r",
-                  "    pm.expect(result.errors[1].location).to.eql(\"body\")\r",
+                  "pm.test(\"ACM requires a MEBx password\", function () {\r",
+                  "    pm.expect(responseBody.message).to.eql(\"MEBx password is required for acmactivate\")\r",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -6237,7 +6233,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\r\n    \"profileName\": \"profile6\",\r\n    \"activation\": \"acmactivate\",\r\n    \"generateRandomPassword\": false,\r\n    \"generateRandomMEBxPassword\": false\r\n}"
+              "raw": "{\r\n    \"profileName\": \"profile6\",\r\n    \"activation\": \"acmactivate\",\r\n    \"generateRandomPassword\": false,\r\n    \"generateRandomMEBxPassword\": false,\r\n    \"version\": {{profile6Version}}\r\n}"
             },
             "url": {
               "raw": "{{protocol}}://{{host}}/api/v1/admin/profiles/",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -520,8 +520,8 @@ paths:
         The profileName can not be changed.
 
         **Version must be provided to ensure the correct profile is edited.**
-          
-        The amtPassword and mebxPassword are stored in a secrets manager and are only used during activation and configuration, respectively, to set these credentials in the AMT device.
+
+        The amtPassword and mebxPassword are stored in a secrets manager and are only used during activation and configuration, respectively, to set these credentials in the AMT device. Both are optional on update - when omitted, the currently stored value is left unchanged. When provided, they must meet the AMT password complexity requirements. Note: acmactivate (admin control mode) requires a mebxPassword - either provide one, enable generateRandomMEBxPassword, or keep an already-stored value; switching to acmactivate without any of these is rejected.
 
         **Warning:** Choosing CIRA or TLS is **highly recommended**. By choosing 'none', an unsecure and unsafe channel is used for communication between the AMT device and MPS and is vulnerable to attacks.  To use neither, set both 'tlsMode' and 'ciraConfigName' to **null**.
       requestBody:


### PR DESCRIPTION
 amtPassword/mebxPassword now optional on PATCH; stored secrets are preserved
 when omitted. Create validation and complexity rules unchanged.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
