### PR TITLE
fix(activation): don't retry one-shot ACM activation calls on timeout

### DIFF
--- a/src/stateMachines/activation.test.ts
+++ b/src/stateMachines/activation.test.ts
@@ -466,7 +466,8 @@ describe('Activation State Machine', () => {
       devices[clientId].nonce = PasswordHelper.generateNonce()
       await activation.sendAdminSetup({ input: context })
       expect(createSignedStringSpy).toHaveBeenCalled()
-      expect(invokeWsmanCallSpy).toHaveBeenCalled()
+      // AdminSetup is one-shot: AMT drops the session on success without replying.
+      expect(invokeWsmanCallSpy).toHaveBeenCalledWith(context, 0, undefined, true)
     })
     it('should return null when signature in null', async () => {
       context.certChainPfx = { provisioningCertificateObj: { certChain: [
@@ -496,7 +497,7 @@ describe('Activation State Machine', () => {
             null }, fingerprint: { sha256: '82f2ed575db4abe462499cf550dbff9584980d70a0272894639c3653b9ad932c', sha384: 'bb00173b0fb55bc1b24fff5a32a02d210d2bbe16dc6ba4f8300729c1d545313a66930bcd1bcf9ed5a76e82ce602ef04a', sha1: '47d7b7db23f3e300189f54802482b1bd18b945ef' }, hashAlgorithm: 'sha256' }
       await activation.sendUpgradeClientToAdmin({ input: context })
       expect(createSignedStringSpy).toHaveBeenCalled()
-      expect(invokeWsmanCallSpy).toHaveBeenCalled()
+      expect(invokeWsmanCallSpy).toHaveBeenCalledWith(context, 0, undefined, true)
     })
     it('should send WSMan to change AMT password', async () => {
       await activation.changeAMTPassword({ input: context })

--- a/src/stateMachines/activation.ts
+++ b/src/stateMachines/activation.ts
@@ -284,7 +284,8 @@ export class Activation {
         2,
         clientObj.signature
       )
-      return await invokeWsmanCall(input)
+      // One-shot: ACM activation drops the session on success; don't retry (state machine re-checks status).
+      return await invokeWsmanCall(input, 0, undefined, true)
     }
     return null
   }
@@ -300,7 +301,8 @@ export class Activation {
         2,
         clientObj.signature
       )
-      return await invokeWsmanCall(input)
+      // One-shot: CCM->ACM upgrade drops the session on success; don't retry (state machine re-checks status).
+      return await invokeWsmanCall(input, 0, undefined, true)
     }
     return null
   }

--- a/src/stateMachines/common.test.ts
+++ b/src/stateMachines/common.test.ts
@@ -136,6 +136,39 @@ describe('Common', () => {
     expect(sendSpy).toHaveBeenCalledTimes(1)
     await expect(wsmanPromise).rejects.toBeInstanceOf(UNEXPECTED_PARSE_ERROR)
   })
+  it('should cap oneShot calls to a single attempt even when wsman_max_attempts > 1', async () => {
+    Environment.Config.wsman_max_attempts = 3
+    sendSpy = vi.spyOn(devices[clientId].ClientSocket, 'send')
+    sendSpy.mockImplementation(async () => devices[clientId].reject(new UNEXPECTED_PARSE_ERROR()))
+    const wsmanPromise = invokeWsmanCall(context, 0, undefined, true)
+    await expect(wsmanPromise).rejects.toBeInstanceOf(UNEXPECTED_PARSE_ERROR)
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+  })
+  it('should honor the wsman_max_attempts floor when oneShot is false', async () => {
+    Environment.Config.wsman_max_attempts = 3
+    sendSpy = vi.spyOn(devices[clientId].ClientSocket, 'send')
+    sendSpy.mockImplementation(async () => devices[clientId].reject(new UNEXPECTED_PARSE_ERROR()))
+    const wsmanPromise = invokeWsmanCall(context)
+    await expect(wsmanPromise).rejects.toBeInstanceOf(UNEXPECTED_PARSE_ERROR)
+    expect(sendSpy).toHaveBeenCalledTimes(3)
+  })
+  it('should not log exhaustion for the expected oneShot timeout', async () => {
+    const errorLogSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => {})
+    const wsmanPromise = invokeWsmanCall(context, 0, undefined, true)
+    vi.advanceTimersByTime(Environment.Config.delay_timer * 1000)
+    await expect(wsmanPromise).rejects.toBeInstanceOf(GATEWAY_TIMEOUT_ERROR)
+    expect(errorLogSpy).not.toHaveBeenCalledWith(expect.stringContaining('Max WSMAN attempts'))
+    errorLogSpy.mockRestore()
+  })
+  it('should log exhaustion for a non-timeout oneShot failure', async () => {
+    const errorLogSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => {})
+    sendSpy = vi.spyOn(devices[clientId].ClientSocket, 'send')
+    sendSpy.mockImplementation(async () => devices[clientId].reject(new UNEXPECTED_PARSE_ERROR()))
+    const wsmanPromise = invokeWsmanCall(context, 0, undefined, true)
+    await expect(wsmanPromise).rejects.toBeInstanceOf(UNEXPECTED_PARSE_ERROR)
+    expect(errorLogSpy).toHaveBeenCalledWith(expect.stringContaining('Max WSMAN attempts'))
+    errorLogSpy.mockRestore()
+  })
   it('should not retry when error is not UNEXPECTED_PARSE_ERROR', async () => {
     const expected = {
       statusCode: 401,

--- a/src/stateMachines/common.ts
+++ b/src/stateMachines/common.ts
@@ -279,7 +279,7 @@ const timeout = async (ms: number): Promise<void> => {
   })
 }
 
-const invokeWsmanCall = async <T>(context: any, maxRetries = 0, timeoutMs?: number): Promise<T> => {
+const invokeWsmanCall = async <T>(context: any, maxRetries = 0, timeoutMs?: number, oneShot = false): Promise<T> => {
   const { clientId } = context
   const clientObj = devices[clientId]
 
@@ -293,7 +293,8 @@ const invokeWsmanCall = async <T>(context: any, maxRetries = 0, timeoutMs?: numb
   }
 
   let retriesUsed = 0
-  const maxAttempts = Math.max(maxRetries + 1, Environment.Config.wsman_max_attempts)
+  // One-shot calls (ACM activation/upgrade) drop the session on success; never re-issue them.
+  const maxAttempts = oneShot ? 1 : Math.max(maxRetries + 1, Environment.Config.wsman_max_attempts)
   const timeoutValue = timeoutMs ?? Environment.Config.delay_timer * 1000
   const retryDelayMs = Environment.Config.delay_tls_timer * 1000
 
@@ -353,7 +354,9 @@ const invokeWsmanCall = async <T>(context: any, maxRetries = 0, timeoutMs?: numb
         continue
       }
 
-      if (isRetryableError && retriesUsed >= maxAttempts - 1) {
+      // Skip the exhaustion log only for the expected one-shot timeout; still log real failures.
+      const isExpectedOneShotTimeout = oneShot && error instanceof GATEWAY_TIMEOUT_ERROR
+      if (isRetryableError && retriesUsed >= maxAttempts - 1 && !isExpectedOneShotTimeout) {
         const errorType = (error as any)?.constructor?.name ?? typeof error
         const tunnelState = clientObj?.tlsTunnelManager != null ? 'present' : 'none'
         const sessionId = clientObj?.tlsTunnelSessionId ?? 'none'
@@ -363,10 +366,8 @@ const invokeWsmanCall = async <T>(context: any, maxRetries = 0, timeoutMs?: numb
         invokeWsmanLogger.error(
           `WSMAN final failure context: attempts=${maxAttempts}, retriesUsed=${retriesUsed}, errorType=${errorType}, tunnelState=${tunnelState}, sessionId=${sessionId}, tunnelNeedsReset=${clientObj?.tlsTunnelNeedsReset === true}, amtReconfiguring=${clientObj?.amtReconfiguring === true}`
         )
-        throw error
-      } else {
-        throw error
       }
+      throw error
     }
   }
   return await Promise.reject(new Error('Max retries reached'))


### PR DESCRIPTION
On a successful ACM activation (AdminSetup) or CCM->ACM upgrade (UpgradeClientToAdmin), AMT transitions to admin mode and drops the session without sending a WSMAN response, so a gateway timeout is the expected outcome. invokeWsmanCall was treating that timeout as retryable (wsman_max_attempts floor) and re-issuing the non-idempotent call against a device already in ACM, producing HTTP 401 / connection resets and eventually an uncaught exception.

Add an opt-in oneShot flag to invokeWsmanCall that caps the call at a single attempt, and use it for sendAdminSetup and sendUpgradeClientToAdmin so the timeout propagates to the state machine, which waits and re-queries device status via CHECK_ACTIVATION_ON_AMT. 

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
