### PR TITLE
feat(activation): structured per-component provisioning result

### DIFF
--- a/src/models/RCS.Config.ts
+++ b/src/models/RCS.Config.ts
@@ -88,11 +88,40 @@ export interface RemoteConfig {
   AMTDomains: AMTDomain[]
 }
 
+/**
+ * Per-component activation outcome. Additive structured detail that rides alongside the
+ * legacy flat status strings in the WebSocket `message` field (see issue #2665). Older
+ * clients that do not understand `Components` simply ignore it.
+ */
+export type ComponentResultStatus = 'Success' | 'Failure' | 'NotApplicable'
+
+/** Clean machine-readable mode enum for a component result. Prose belongs in Details. */
+export type ComponentMode = 'ACM' | 'CCM' | 'LocalProfileSync'
+
+export interface ComponentResult {
+  Result: ComponentResultStatus
+  Mode?: ComponentMode
+  /** Human-readable, sentence-case note (no trailing period). On failure this carries the reason. */
+  Details?: string
+}
+
+export interface ComponentResults {
+  Activation?: ComponentResult
+  WiredNetwork?: ComponentResult
+  WirelessNetwork?: ComponentResult
+  TLS?: ComponentResult
+  CIRAProxy?: ComponentResult
+  CIRAConnection?: ComponentResult
+}
+
 export interface Status {
   Status?: string
   Network?: string
   CIRAConnection?: string
   TLSConfiguration?: string
+  // Additive structured per-component results (issue #2665). The legacy flat fields above are
+  // always populated for backwards compatibility; Components carries the granular per-component breakdown.
+  Components?: ComponentResults
 }
 export interface ClientObject {
   ClientId: string

--- a/src/stateMachines/activation.test.ts
+++ b/src/stateMachines/activation.test.ts
@@ -36,6 +36,10 @@ vi.mock('./common.js', async () => {
     invokeWsmanCall: invokeWsmanCallSpy,
     invokeEnterpriseAssistantCall: vi.fn(),
     processTLSTunnelResponse: vi.fn(),
+    recordComponentResult: actual.recordComponentResult,
+    deriveControlMode: actual.deriveControlMode,
+    finalizeComponentResults: actual.finalizeComponentResults,
+    applicableComponents: actual.applicableComponents,
     HttpResponseError,
     isDigestRealmValid,
     coalesceMessage
@@ -829,6 +833,11 @@ describe('Activation State Machine', () => {
       devices[context.clientId].status.Status = 'Admin control mode.'
       activation.setActivationStatus({ context })
       expect(devices[clientId].activationStatus).toBeTruthy()
+      expect(devices[clientId].status.Components?.Activation).toEqual({
+        Result: 'Success',
+        Mode: 'ACM',
+        Details: 'Admin control mode'
+      })
     })
   })
 
@@ -2082,8 +2091,18 @@ describe('Activation State Machine', () => {
       }))
 
     it('should send success message to device', () => {
+      context.status = 'success'
+      devices[clientId].status = { Status: 'Admin control mode.' }
       activation.sendMessageToDevice({ context })
       expect(sendSpy).toHaveBeenCalled()
+      expect(devices[clientId].status.Components?.Activation?.Result).toEqual('Success')
+      // The full status is sent to RPC, keeping the legacy prose Status for backwards compatibility
+      // alongside the structured Components block. The confusing roll-up/version fields are gone.
+      const sentPayload = JSON.parse(responseMessageSpy.mock.calls[0][4])
+      expect(sentPayload.Status).toEqual('Admin control mode.')
+      expect(sentPayload.Components?.Activation?.Result).toEqual('Success')
+      expect(sentPayload.ComponentsRollup).toBeUndefined()
+      expect(sentPayload.ComponentsVersion).toBeUndefined()
     })
     it('should update Credentials', () => {
       activation.updateCredentials({ context })
@@ -2093,7 +2112,10 @@ describe('Activation State Machine', () => {
     it('should send error message to device', () => {
       context.status = 'error'
       context.message = null
+      // Device never reached an activated control mode, so Activation is recorded as a Failure.
+      devices[clientId].activationStatus = false
       activation.sendMessageToDevice({ context })
+      // The full status object is serialized to RPC unchanged for backwards compatibility (issue #2665).
       expect(responseMessageSpy).toHaveBeenCalledWith(
         context.clientId,
         context.message,
@@ -2101,7 +2123,34 @@ describe('Activation State Machine', () => {
         'failed',
         JSON.stringify(devices[clientId].status)
       )
+      const sentPayload = JSON.parse(responseMessageSpy.mock.calls[0][4])
+      expect(sentPayload.ComponentsRollup).toBeUndefined()
+      expect(sentPayload.ComponentsVersion).toBeUndefined()
+      expect(devices[clientId].status.Components?.Activation?.Result).toEqual('Failure')
       expect(sendSpy).toHaveBeenCalled()
+    })
+
+    it('on a component failure, sends the full NotApplicable set to RPC but logs only the components that ran', () => {
+      context.status = 'error'
+      context.message = null
+      devices[clientId].activationStatus = false
+      // TLS genuinely ran and failed; nothing else was attempted.
+      devices[clientId].status = { Components: { TLS: { Result: 'Failure', Details: 'TLS handshake failed' } } }
+      const loggerSpy = vi.spyOn(activation.logger, 'info')
+      activation.sendMessageToDevice({ context })
+
+      // Wire to RPC: full set incl. the NotApplicable backfill (backwards compatibility).
+      const sentPayload = JSON.parse(responseMessageSpy.mock.calls[0][4])
+      expect(sentPayload.Components.TLS.Result).toEqual('Failure')
+      expect(sentPayload.Components.CIRAProxy.Result).toEqual('NotApplicable')
+      expect(sentPayload.Components.WiredNetwork.Result).toEqual('NotApplicable')
+
+      // Log: the failed TLS stays; the NotApplicable fillers are stripped out.
+      const logged = JSON.parse(loggerSpy.mock.calls.at(-1)?.[0] as string)
+      expect(logged.Components.TLS.Result).toEqual('Failure')
+      expect(logged.Components.Activation.Result).toEqual('Failure')
+      expect(logged.Components.CIRAProxy).toBeUndefined()
+      expect(logged.Components.WiredNetwork).toBeUndefined()
     })
   })
 

--- a/src/stateMachines/activation.ts
+++ b/src/stateMachines/activation.ts
@@ -25,7 +25,15 @@ import { DbCreatorFactory } from '../factories/DbCreatorFactory.js'
 import { AMTUserName, GATEWAY_TIMEOUT_ERROR, asArray } from '../utils/constants.js'
 import { CIRAConfiguration } from './ciraConfiguration.js'
 import { TLS } from './tls.js'
-import { type CommonContext, invokeWsmanCall, processTLSTunnelResponse } from './common.js'
+import {
+  type CommonContext,
+  invokeWsmanCall,
+  processTLSTunnelResponse,
+  recordComponentResult,
+  deriveControlMode,
+  finalizeComponentResults,
+  applicableComponents
+} from './common.js'
 import ClientResponseMsg from '../utils/ClientResponseMsg.js'
 import { Unconfiguration } from './unconfiguration.js'
 import { type DeviceCredentials } from '../interfaces/ISecretManagerService.js'
@@ -137,11 +145,24 @@ export class Activation {
     if (status === 'success') {
       method = 'success'
     } else {
-      clientObj.status.Status = context.errorMessage !== '' ? context.errorMessage : 'Failed'
+      // errorMessage is optional/untyped — guard against undefined, not just '' (issue #2665).
+      clientObj.status.Status = context.errorMessage ? context.errorMessage : 'Failed'
       method = 'failed'
+      // Record the Activation component as a failure when the device never reached an
+      // activated control mode (issue #2665). If it activated but a later component failed,
+      // 'Set activation status' already recorded Activation as a success — don't overwrite it.
+      if (clientObj.activationStatus !== true) {
+        recordComponentResult(clientId, 'Activation', {
+          Result: 'Failure',
+          Details: clientObj.status.Status
+        })
+      }
     }
+    finalizeComponentResults(clientId, status === 'success')
+    // Full status to RPC for backwards compatibility.
     const responseMessage = ClientResponseMsg.get(clientId, null, status, method, JSON.stringify(clientObj.status))
-    this.logger.info(JSON.stringify(responseMessage, null, '\t'))
+    // Log only the components that ran.
+    this.logger.info(JSON.stringify({ Components: applicableComponents(clientObj.status.Components) }, null, '\t'))
     devices[clientId].ClientSocket?.send(JSON.stringify(responseMessage))
   }
 
@@ -428,6 +449,11 @@ export class Activation {
     const clientObj = devices[context.clientId]
     this.logger.debug(`Device ${clientObj.uuid} activated in ${clientObj.status.Status}.`)
     clientObj.activationStatus = true
+    recordComponentResult(context.clientId, 'Activation', {
+      Result: 'Success',
+      Mode: deriveControlMode(clientObj.status.Status),
+      Details: clientObj.status.Status
+    })
     MqttProvider.publishEvent(
       'success',
       ['Activator', 'execute'],

--- a/src/stateMachines/ciraConfiguration.test.ts
+++ b/src/stateMachines/ciraConfiguration.test.ts
@@ -29,6 +29,7 @@ vi.mock('./common.js', async () => {
     invokeWsmanCall: invokeWsmanCallSpy,
     invokeEnterpriseAssistantCall: vi.fn(),
     processTLSTunnelResponse: vi.fn(),
+    recordComponentResult: actual.recordComponentResult,
     HttpResponseError,
     isDigestRealmValid,
     coalesceMessage
@@ -183,6 +184,10 @@ describe('CIRA Configuration State Machine', () => {
               if (state.matches('SUCCESS') || state.matches('FAILURE') || currentStateIndex === flowStates.length) {
                 const status = devices[clientId].status.CIRAConnection
                 expect(status).toEqual('Configured')
+                expect(devices[clientId].status.Components?.CIRAConnection).toEqual({
+                  Result: 'Success',
+                  Details: 'Configured'
+                })
                 resolve()
               }
             }
@@ -212,6 +217,7 @@ describe('CIRA Configuration State Machine', () => {
           try {
             if (state.matches('SUCCESS') || state.matches('FAILURE')) {
               expect(state.matches('FAILURE')).toBeTruthy()
+              expect(devices[clientId].status.Components?.CIRAConnection?.Result).toEqual('Failure')
               resolve()
             }
           } catch (err) {

--- a/src/stateMachines/ciraConfiguration.ts
+++ b/src/stateMachines/ciraConfiguration.ts
@@ -22,7 +22,10 @@ import { type DeviceCredentials } from '../interfaces/ISecretManagerService.js'
 import { type AMTConfiguration } from '../models/index.js'
 import { randomUUID } from 'node:crypto'
 import { Error } from './error.js'
-import { type CommonContext, invokeWsmanCall } from './common.js'
+import { type CommonContext, invokeWsmanCall, recordComponentResult } from './common.js'
+
+/** Status string marking a successful CIRA configuration; shared by producer and consumer. */
+const CIRA_CONFIGURED_STATUS = 'Configured'
 
 export interface CIRAConfigContext extends CommonContext {
   status: 'success' | 'error' | 'wsman' | 'heartbeat_request'
@@ -315,6 +318,11 @@ export class CIRAConfiguration {
     actions: {
       'Update Configuration Status': ({ context, event }) => {
         devices[context.clientId].status.CIRAConnection = context.statusMessage
+        const success = context.statusMessage === CIRA_CONFIGURED_STATUS
+        recordComponentResult(context.clientId, 'CIRAConnection', {
+          Result: success ? 'Success' : 'Failure',
+          Details: context.statusMessage
+        })
       },
       'Reset Unauth Count': ({ context, event }) => {
         devices[context.clientId].unauthCount = 0
@@ -831,7 +839,7 @@ export class CIRAConfiguration {
         type: 'final'
       },
       SUCCESS: {
-        entry: [assign({ statusMessage: () => 'Configured' }), 'Update Configuration Status'],
+        entry: [assign({ statusMessage: () => CIRA_CONFIGURED_STATUS }), 'Update Configuration Status'],
         type: 'final'
       }
     }

--- a/src/stateMachines/common.test.ts
+++ b/src/stateMachines/common.test.ts
@@ -18,7 +18,14 @@ import {
   invokeEnterpriseAssistantCall,
   invokeEnterpriseAssistantCallInternal,
   invokeWsmanCall,
-  coalesceMessage
+  coalesceMessage,
+  recordComponentResult,
+  normalizeDetails,
+  deriveControlMode,
+  deriveModeFromCurrentMode,
+  finalizeComponentResults,
+  updateNetworkStatus,
+  applicableComponents
 } from './common.js'
 
 Environment.Config = config
@@ -227,5 +234,206 @@ describe('Common', () => {
     expect(msg).toContain(prefix)
     expect(msg).toContain('Bad Request')
     expect(msg).toContain('400')
+  })
+
+  describe('recordComponentResult', () => {
+    it('should initialize Components and record a result (issue #2665)', () => {
+      devices[clientId].status = { Status: 'Admin control mode.' }
+      recordComponentResult(clientId, 'Activation', {
+        Result: 'Success',
+        Mode: 'ACM'
+      })
+      expect(devices[clientId].status.Components?.Activation).toEqual({
+        Result: 'Success',
+        Mode: 'ACM'
+      })
+    })
+
+    it('should preserve previously recorded components when adding another', () => {
+      devices[clientId].status = { Components: { Activation: { Result: 'Success' } } }
+      recordComponentResult(clientId, 'WirelessNetwork', {
+        Result: 'Failure',
+        Details: 'Failed to add 1'
+      })
+      expect(devices[clientId].status.Components?.Activation).toEqual({ Result: 'Success' })
+      expect(devices[clientId].status.Components?.WirelessNetwork).toEqual({
+        Result: 'Failure',
+        Details: 'Failed to add 1'
+      })
+    })
+
+    it('should normalize the failure detail and carry the reason in Details', () => {
+      devices[clientId].status = {}
+      recordComponentResult(clientId, 'TLS', { Result: 'Failure', Details: 'cert add rejected.' })
+      expect(devices[clientId].status.Components?.TLS).toEqual({
+        Result: 'Failure',
+        Details: 'Cert add rejected'
+      })
+    })
+
+    it('should no-op when the device has no status object', () => {
+      delete (devices[clientId] as any).status
+      expect(() => {
+        recordComponentResult(clientId, 'TLS', { Result: 'Success' })
+      }).not.toThrow()
+      expect(devices[clientId].status).toBeUndefined()
+    })
+  })
+
+  describe('normalizeDetails', () => {
+    it('strips a single trailing period and capitalizes the first character', () => {
+      expect(normalizeDetails('already enabled in admin mode.')).toEqual('Already enabled in admin mode')
+    })
+    it('leaves already-clean strings untouched', () => {
+      expect(normalizeDetails('Wired Network Configured')).toEqual('Wired Network Configured')
+    })
+    it('handles empty/whitespace input', () => {
+      expect(normalizeDetails('   ')).toEqual('')
+    })
+  })
+
+  describe('deriveControlMode', () => {
+    it('maps admin strings to ACM', () => {
+      expect(deriveControlMode('already enabled in admin mode.')).toEqual('ACM')
+    })
+    it('maps client strings to CCM', () => {
+      expect(deriveControlMode('Client control mode.')).toEqual('CCM')
+    })
+    it('returns undefined for unrecognized modes', () => {
+      expect(deriveControlMode('something else')).toBeUndefined()
+    })
+  })
+
+  describe('deriveModeFromCurrentMode', () => {
+    it('maps currentMode 1 to CCM', () => {
+      expect(deriveModeFromCurrentMode(1)).toEqual('CCM')
+    })
+    it('maps currentMode 2 to ACM', () => {
+      expect(deriveModeFromCurrentMode(2)).toEqual('ACM')
+    })
+    it('returns undefined for pre-provisioning (0) or an absent mode', () => {
+      expect(deriveModeFromCurrentMode(0)).toBeUndefined()
+      expect(deriveModeFromCurrentMode(undefined)).toBeUndefined()
+    })
+  })
+
+  describe('updateNetworkStatus', () => {
+    beforeEach(() => {
+      devices[clientId].status = {}
+    })
+    it('reports an error message as a failure', () => {
+      const result = updateNetworkStatus({ clientId, errorMessage: 'boom', itemLabel: 'Proxy Configurations' })
+      expect(result).toEqual({ message: 'boom', failed: true })
+      expect(devices[clientId].status.Network).toEqual('boom')
+    })
+    it('builds an added/failed summary and flags failure when some items failed', () => {
+      const result = updateNetworkStatus({
+        clientId,
+        added: '2',
+        failedItems: '1',
+        itemLabel: 'WiFi Profiles'
+      })
+      expect(result).toEqual({ message: 'Added 2 WiFi Profiles. Failed to add 1', failed: true })
+    })
+    it('reports the status message as a success when nothing failed', () => {
+      const result = updateNetworkStatus({ clientId, statusMessage: 'Configured', itemLabel: 'WiFi Profiles' })
+      expect(result).toEqual({ message: 'Configured', failed: false })
+    })
+    it('appends to an existing Network status rather than overwriting it', () => {
+      devices[clientId].status.Network = 'Prior'
+      updateNetworkStatus({ clientId, statusMessage: 'Configured', itemLabel: 'WiFi Profiles' })
+      expect(devices[clientId].status.Network).toEqual('Prior. Configured')
+    })
+    it('leaves Network untouched when no message is produced (no literal "undefined")', () => {
+      devices[clientId].status.Network = 'Prior'
+      const result = updateNetworkStatus({ clientId, itemLabel: 'WiFi Profiles' })
+      expect(result).toEqual({ message: undefined, failed: false })
+      expect(devices[clientId].status.Network).toEqual('Prior')
+    })
+  })
+
+  describe('finalizeComponentResults', () => {
+    it('backfills NotApplicable components and the Activation entry', () => {
+      devices[clientId].status = {
+        Status: 'already enabled in admin mode.',
+        Components: { TLS: { Result: 'Success' } }
+      }
+      finalizeComponentResults(clientId, true)
+      const status = devices[clientId].status
+      // Already-activated device: Activation is backfilled from the legacy flat status.
+      expect(status.Components?.Activation).toEqual({
+        Result: 'Success',
+        Mode: 'ACM',
+        Details: 'Already enabled in admin mode'
+      })
+      // Every remaining component is present as NotApplicable.
+      expect(status.Components?.CIRAConnection?.Result).toEqual('NotApplicable')
+      expect(status.Components?.WiredNetwork?.Result).toEqual('NotApplicable')
+    })
+
+    it('backfills Activation as ACM for an already-activated device from the reported control mode', () => {
+      // Pure reconfigure: mode comes from currentMode (2 = ACM).
+      devices[clientId].ClientData = { payload: { currentMode: 2 } } as any
+      devices[clientId].status = { Components: { CIRAConnection: { Result: 'Success' } } }
+      finalizeComponentResults(clientId, true)
+      expect(devices[clientId].status.Components?.Activation).toEqual({
+        Result: 'Success',
+        Mode: 'ACM',
+        Details: 'Device already activated in admin control mode'
+      })
+    })
+
+    it('backfills Activation as CCM for an already-activated device from the reported control mode', () => {
+      devices[clientId].ClientData = { payload: { currentMode: 1 } } as any
+      devices[clientId].status = { Components: { CIRAConnection: { Result: 'Success' } } }
+      finalizeComponentResults(clientId, true)
+      expect(devices[clientId].status.Components?.Activation).toEqual({
+        Result: 'Success',
+        Mode: 'CCM',
+        Details: 'Device already activated in client control mode'
+      })
+    })
+
+    it('leaves Activation NotApplicable when neither a status string nor a control mode is available', () => {
+      devices[clientId].ClientData = { payload: {} } as any
+      devices[clientId].status = { Components: { CIRAConnection: { Result: 'Success' } } }
+      finalizeComponentResults(clientId, true)
+      expect(devices[clientId].status.Components?.Activation?.Result).toEqual('NotApplicable')
+    })
+
+    it('does not backfill Activation on the failure path', () => {
+      devices[clientId].status = { Status: 'Failed', Components: {} }
+      finalizeComponentResults(clientId, false)
+      expect(devices[clientId].status.Components?.Activation?.Result).toEqual('NotApplicable')
+    })
+
+    it('no-ops when the device has no status object', () => {
+      delete (devices[clientId] as any).status
+      expect(() => {
+        finalizeComponentResults(clientId, true)
+      }).not.toThrow()
+    })
+  })
+
+  describe('applicableComponents', () => {
+    it('keeps Success and Failure entries, drops NotApplicable', () => {
+      const result = applicableComponents({
+        Activation: { Result: 'Success', Mode: 'ACM' },
+        TLS: { Result: 'Failure', Details: 'TLS handshake failed' },
+        CIRAProxy: { Result: 'NotApplicable', Details: 'CIRA proxy not part of this configuration' },
+        WiredNetwork: { Result: 'NotApplicable' }
+      })
+      expect(result).toEqual({
+        Activation: { Result: 'Success', Mode: 'ACM' },
+        TLS: { Result: 'Failure', Details: 'TLS handshake failed' }
+      })
+    })
+
+    it('returns an empty object for undefined or all-NotApplicable input', () => {
+      expect(applicableComponents(undefined)).toEqual({})
+      expect(
+        applicableComponents({ TLS: { Result: 'NotApplicable' }, CIRAProxy: { Result: 'NotApplicable' } })
+      ).toEqual({})
+    })
   })
 })

--- a/src/stateMachines/common.ts
+++ b/src/stateMachines/common.ts
@@ -20,6 +20,7 @@ import {
 } from '../utils/constants.js'
 import Logger from '../Logger.js'
 import { type HttpHandler } from '../HttpHandler.js'
+import { type ComponentResult, type ComponentResults } from '../models/RCS.Config.js'
 import pkg, { type HttpZResponseModel } from 'http-z'
 import { parseChunkedMessage } from '../utils/parseChunkedMessage.js'
 import { TLSTunnelManager } from '../TLSTunnelManager.js'
@@ -418,6 +419,183 @@ export function coalesceMessage(prefixMsg: string, err: any): string {
     }
   }
   return msg
+}
+
+// Every component RPS can report on. Used to backfill 'NotApplicable' entries so the
+// Components block always carries the full, predictable key set (issue #2665).
+const ALL_COMPONENTS: (keyof ComponentResults)[] = [
+  'Activation',
+  'WiredNetwork',
+  'WirelessNetwork',
+  'TLS',
+  'CIRAProxy',
+  'CIRAConnection'
+]
+
+const NOT_APPLICABLE_DETAILS: Record<keyof ComponentResults, string> = {
+  Activation: 'Activation not part of this configuration',
+  WiredNetwork: 'Wired network not part of this configuration',
+  WirelessNetwork: 'Wireless network not part of this configuration',
+  TLS: 'TLS not part of this configuration',
+  CIRAProxy: 'CIRA proxy not part of this configuration',
+  CIRAConnection: 'CIRA connection not part of this configuration'
+}
+
+/**
+ * Normalizes a human-readable detail string to sentence-case with no trailing period, so the
+ * structured Components block reads consistently regardless of which child machine produced it.
+ */
+export function normalizeDetails(details: string): string {
+  const trimmed = details.trim().replace(/\.+$/, '')
+  if (trimmed.length === 0) {
+    return trimmed
+  }
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1)
+}
+
+/**
+ * Maps a legacy control-mode status string onto a clean machine-readable mode enum.
+ * Returns undefined when the string is absent or carries no recognizable control mode.
+ */
+export function deriveControlMode(statusMessage: string | undefined): 'ACM' | 'CCM' | undefined {
+  if (statusMessage == null) {
+    return undefined
+  }
+  const normalized = statusMessage.toLowerCase()
+  if (normalized.includes('admin')) {
+    return 'ACM'
+  }
+  if (normalized.includes('client')) {
+    return 'CCM'
+  }
+  return undefined
+}
+
+/** Maps the device-reported AMT control mode (1 = CCM, 2 = ACM) onto the result Mode enum. */
+export function deriveModeFromCurrentMode(currentMode: number | undefined): 'ACM' | 'CCM' | undefined {
+  if (currentMode === 1) {
+    return 'CCM'
+  }
+  if (currentMode === 2) {
+    return 'ACM'
+  }
+  return undefined
+}
+
+/** Builds the proxy/wifi "added N / failed M" status, appends it to status.Network, returns message + failure flag. */
+export function updateNetworkStatus(opts: {
+  clientId: string
+  errorMessage?: string
+  statusMessage?: string
+  added?: string | null
+  failedItems?: string | null
+  itemLabel: string
+}): { message: string | undefined; failed: boolean } {
+  const { clientId, errorMessage, statusMessage, added, failedItems, itemLabel } = opts
+  const device = devices[clientId]
+  const networkStatus = device.status.Network
+  let message: string | undefined
+  if (errorMessage) {
+    message = errorMessage
+  } else if (failedItems) {
+    message =
+      added != null ? `Added ${added} ${itemLabel}. Failed to add ${failedItems}` : `Failed to add ${failedItems}`
+  } else {
+    message = statusMessage
+  }
+  if (message != null) {
+    device.status.Network = networkStatus ? `${networkStatus}. ${message}` : message
+  }
+  return { message, failed: !!errorMessage || !!failedItems }
+}
+
+/**
+ * Records a structured per-component activation result onto the shared device status object
+ * (issue #2665). This is additive: it sits alongside the legacy flat status strings and is
+ * serialized into the final WebSocket `message` payload. Recording a component result never
+ * alters control flow — a failure is captured for visibility but does not change the
+ * activation outcome.
+ *
+ * Shape invariants enforced here: Details are normalized to sentence-case (the failure reason rides
+ * in Details), and undefined optional fields are omitted.
+ */
+export function recordComponentResult(
+  clientId: string,
+  component: keyof ComponentResults,
+  result: ComponentResult
+): void {
+  const clientObj = devices[clientId]
+  if (clientObj?.status == null) {
+    return
+  }
+  if (clientObj.status.Components == null) {
+    clientObj.status.Components = {}
+  }
+  const normalized: ComponentResult = { Result: result.Result }
+  if (result.Mode != null) {
+    normalized.Mode = result.Mode
+  }
+  if (result.Details != null) {
+    normalized.Details = normalizeDetails(result.Details)
+  }
+  clientObj.status.Components[component] = normalized
+}
+
+/**
+ * Finalizes the structured Components block just before it is serialized to the device (issue #2665):
+ * backfills Activation for already-activated devices that skipped the activation steps, and fills every
+ * un-attempted component with a NotApplicable entry so the key set is always complete. Additive only —
+ * the legacy flat status strings are left untouched for backwards compatibility.
+ */
+export function finalizeComponentResults(clientId: string, overallSuccess: boolean): void {
+  const clientObj = devices[clientId]
+  if (clientObj?.status == null) {
+    return
+  }
+  const status = clientObj.status
+  if (status.Components == null) {
+    status.Components = {}
+  }
+  // Backfill Activation for already-activated devices (fresh activations already recorded it).
+  if (overallSuccess && status.Components.Activation == null) {
+    if (status.Status != null) {
+      // Activated this session: prose status carries the mode.
+      recordComponentResult(clientId, 'Activation', {
+        Result: 'Success',
+        Mode: deriveControlMode(status.Status),
+        Details: status.Status
+      })
+    } else {
+      // Pure reconfigure: status.Status unset, so use the reported control mode.
+      const mode = deriveModeFromCurrentMode(clientObj.ClientData?.payload?.currentMode)
+      if (mode != null) {
+        recordComponentResult(clientId, 'Activation', {
+          Result: 'Success',
+          Mode: mode,
+          Details: `Device already activated in ${mode === 'ACM' ? 'admin' : 'client'} control mode`
+        })
+      }
+    }
+  }
+  for (const component of ALL_COMPONENTS) {
+    if (status.Components[component] == null) {
+      status.Components[component] = { Result: 'NotApplicable', Details: NOT_APPLICABLE_DETAILS[component] }
+    }
+  }
+}
+
+/** Drops NotApplicable entries (for logging only — the full set still goes to RPC). */
+export function applicableComponents(components: ComponentResults | undefined): ComponentResults {
+  const result: ComponentResults = {}
+  if (components == null) {
+    return result
+  }
+  for (const [name, entry] of Object.entries(components) as [keyof ComponentResults, ComponentResult][]) {
+    if (entry?.Result !== 'NotApplicable') {
+      result[name] = entry
+    }
+  }
+  return result
 }
 
 const isDigestRealmValid = (realm: string): boolean => {

--- a/src/stateMachines/proxyConfiguration.test.ts
+++ b/src/stateMachines/proxyConfiguration.test.ts
@@ -98,6 +98,7 @@ describe('Proxy Configuration State Machine', () => {
               if (state.matches('FAILED') && currentStateIndex === flowStates.length) {
                 const status = devices[clientId].status.Network
                 expect(status).toContain('Failed to get proxy config from DB')
+                expect(devices[clientId].status.Components?.CIRAProxy?.Result).toEqual('Failure')
                 service.stop()
                 resolve()
               }
@@ -145,6 +146,10 @@ describe('Proxy Configuration State Machine', () => {
               if (state.matches('SUCCESS') && currentStateIndex === flowStates.length) {
                 const status = devices[clientId].status.Network
                 expect(status).toEqual('Initial. Proxy Configured')
+                expect(devices[clientId].status.Components?.CIRAProxy).toEqual({
+                  Result: 'Success',
+                  Details: 'Proxy Configured'
+                })
                 service.stop()
                 resolve()
               }
@@ -193,6 +198,11 @@ describe('Proxy Configuration State Machine', () => {
               if (state.matches('SUCCESS') && currentStateIndex === flowStates.length) {
                 const status = devices[clientId].status.Network
                 expect(status).toEqual('Initial. Failed to add proxy1')
+                // Partial failure (some configs failed) is reported as a CIRAProxy Failure.
+                expect(devices[clientId].status.Components?.CIRAProxy).toEqual({
+                  Result: 'Failure',
+                  Details: 'Failed to add proxy1'
+                })
                 resolve()
               }
             } catch (err) {
@@ -236,6 +246,11 @@ describe('Proxy Configuration State Machine', () => {
               if (state.matches('SUCCESS') && currentStateIndex === flowStates.length) {
                 const status = devices[clientId].status.Network
                 expect(status).toEqual('Initial. Failed to add proxy1')
+                // Partial failure (some configs failed) is reported as a CIRAProxy Failure.
+                expect(devices[clientId].status.Components?.CIRAProxy).toEqual({
+                  Result: 'Failure',
+                  Details: 'Failed to add proxy1'
+                })
                 resolve()
               }
             } catch (err) {

--- a/src/stateMachines/proxyConfiguration.ts
+++ b/src/stateMachines/proxyConfiguration.ts
@@ -9,11 +9,10 @@ import { assign, fromPromise, setup } from 'xstate'
 import { type ProxyConfig } from '../models/RCS.Config.js'
 import Logger from '../Logger.js'
 import { type AMTConfiguration } from '../models/index.js'
-import { devices } from '../devices.js'
 import { Error } from './error.js'
 import { Configurator } from '../Configurator.js'
 import { DbCreatorFactory } from '../factories/DbCreatorFactory.js'
-import { type CommonContext, invokeWsmanCall } from './common.js'
+import { type CommonContext, invokeWsmanCall, recordComponentResult, updateNetworkStatus } from './common.js'
 import { UNEXPECTED_PARSE_ERROR } from '../utils/constants.js'
 
 export interface ProxyConfigContext extends CommonContext {
@@ -101,20 +100,18 @@ export class ProxyConfiguration {
           statusMessage,
           errorMessage
         } = context
-        const device = devices[clientId]
-        const networkStatus = device.status.Network
-        let message
-        if (errorMessage) {
-          message = errorMessage
-        } else if (proxyConfigsFailed) {
-          message =
-            proxyConfigsAdded != null
-              ? `Added ${proxyConfigsAdded} Proxy Configurations. Failed to add ${proxyConfigsFailed}`
-              : `Failed to add ${proxyConfigsFailed}`
-        } else {
-          message = statusMessage
-        }
-        device.status.Network = networkStatus ? `${networkStatus}. ${message}` : message
+        const { message, failed } = updateNetworkStatus({
+          clientId,
+          errorMessage,
+          statusMessage,
+          added: proxyConfigsAdded,
+          failedItems: proxyConfigsFailed,
+          itemLabel: 'Proxy Configurations'
+        })
+        recordComponentResult(clientId, 'CIRAProxy', {
+          Result: failed ? 'Failure' : 'Success',
+          Details: message
+        })
       },
       'Reset Retry Count': assign({ retryCount: () => 0 }),
       'Increment Retry Count': assign({ retryCount: ({ context }) => context.retryCount + 1 }),

--- a/src/stateMachines/tls.test.ts
+++ b/src/stateMachines/tls.test.ts
@@ -17,10 +17,14 @@ import { Environment } from '../utils/Environment.js'
 import { vi } from 'vitest'
 const invokeWsmanCallSpy = vi.hoisted(() => vi.fn<any>())
 const invokeEnterpriseAssistantCallSpy = vi.hoisted(() => vi.fn<any>())
-vi.mock('./common.js', () => ({
-  invokeWsmanCall: invokeWsmanCallSpy,
-  invokeEnterpriseAssistantCall: invokeEnterpriseAssistantCallSpy
-}))
+vi.mock('./common.js', async () => {
+  const actual = await vi.importActual<typeof import('./common.js')>('./common.js')
+  return {
+    invokeWsmanCall: invokeWsmanCallSpy,
+    invokeEnterpriseAssistantCall: invokeEnterpriseAssistantCallSpy,
+    recordComponentResult: actual.recordComponentResult
+  }
+})
 
 const { TLS } = await import('./tls.js')
 
@@ -397,6 +401,10 @@ describe('TLS State Machine', () => {
     context.statusMessage = 'success status message'
     tls.updateConfigurationStatus({ context })
     expect(devices[context.clientId].status.TLSConfiguration).toEqual('success status message')
+    expect(devices[context.clientId].status.Components?.TLS).toEqual({
+      Result: 'Success',
+      Details: 'Success status message'
+    })
     expect(invokeWsmanCallSpy).not.toHaveBeenCalled()
   })
   it('should updateConfigurationStatus when failure', async () => {
@@ -404,6 +412,10 @@ describe('TLS State Machine', () => {
     context.errorMessage = 'error status message'
     tls.updateConfigurationStatus({ context })
     expect(devices[context.clientId].status.TLSConfiguration).toEqual('error status message')
+    expect(devices[context.clientId].status.Components?.TLS).toEqual({
+      Result: 'Failure',
+      Details: 'Error status message'
+    })
     expect(invokeWsmanCallSpy).not.toHaveBeenCalled()
   })
   it('should enumerateTLSData', async () => {

--- a/src/stateMachines/tls.ts
+++ b/src/stateMachines/tls.ts
@@ -22,7 +22,7 @@ import {
   initiateCertRequest,
   sendEnterpriseAssistantKeyPairResponse
 } from './enterpriseAssistant.js'
-import { type CommonContext, invokeWsmanCall } from './common.js'
+import { type CommonContext, invokeWsmanCall, recordComponentResult } from './common.js'
 
 export interface TLSContext extends CommonContext {
   amtProfile: AMTConfiguration | null
@@ -233,8 +233,17 @@ export class TLS {
   updateConfigurationStatus({ context }: { context: TLSContext }): void {
     if (context.status === 'success') {
       devices[context.clientId].status.TLSConfiguration = context.statusMessage
+      recordComponentResult(context.clientId, 'TLS', {
+        Result: 'Success',
+        Details: context.statusMessage
+      })
     } else if (context.status === 'error') {
-      devices[context.clientId].status.TLSConfiguration = context.errorMessage !== '' ? context.errorMessage : 'Failed'
+      const details = context.errorMessage !== '' ? context.errorMessage : 'Failed'
+      devices[context.clientId].status.TLSConfiguration = details
+      recordComponentResult(context.clientId, 'TLS', {
+        Result: 'Failure',
+        Details: details
+      })
     }
   }
 

--- a/src/stateMachines/wifiNetworkConfiguration.test.ts
+++ b/src/stateMachines/wifiNetworkConfiguration.test.ts
@@ -29,6 +29,8 @@ vi.mock('./common.js', async () => {
     invokeWsmanCall: invokeWsmanCallSpy,
     invokeEnterpriseAssistantCall: invokeEnterpriseAssistantCallSpy,
     processTLSTunnelResponse: vi.fn(),
+    recordComponentResult: actual.recordComponentResult,
+    updateNetworkStatus: actual.updateNetworkStatus,
     HttpResponseError,
     isDigestRealmValid,
     coalesceMessage
@@ -273,6 +275,7 @@ describe('WiFi Network Configuration', () => {
                 expect(status).toEqual(
                   'Wired Network Configured. Failed to put Max Retransmissions to ethernet port settings'
                 )
+                expect(devices[clientId].status.Components?.WirelessNetwork?.Result).toEqual('Failure')
                 resolve()
               }
             } catch (err) {
@@ -881,6 +884,10 @@ describe('WiFi Network Configuration', () => {
               if (state.matches('SUCCESS') && currentStateIndex === flowStates.length) {
                 const status = devices[clientId].status.Network
                 expect(status).toEqual('Wired Network Configured. Wireless Configured')
+                expect(devices[clientId].status.Components?.WirelessNetwork).toEqual({
+                  Result: 'Success',
+                  Details: 'Wireless Configured'
+                })
                 resolve()
               }
             } catch (err) {
@@ -928,6 +935,11 @@ describe('WiFi Network Configuration', () => {
               if (state.matches('SUCCESS_SYNC_ONLY') && currentStateIndex === flowStates.length) {
                 const status = devices[clientId].status.Network
                 expect(status).toEqual('Wired Network Configured. Wireless Only Local Profile Sync Configured')
+                expect(devices[clientId].status.Components?.WirelessNetwork).toEqual({
+                  Result: 'Success',
+                  Mode: 'LocalProfileSync',
+                  Details: 'Local Profile Sync Configured'
+                })
                 resolve()
               }
             } catch (err) {
@@ -1173,6 +1185,10 @@ describe('WiFi Network Configuration', () => {
               if (state.matches('SUCCESS') && currentStateIndex === flowStates.length) {
                 const status = devices[clientId].status.Network
                 expect(status).toEqual('Wired Network Configured. Wireless Configured')
+                expect(devices[clientId].status.Components?.WirelessNetwork).toEqual({
+                  Result: 'Success',
+                  Details: 'Wireless Configured'
+                })
                 resolve()
               }
             } catch (err) {

--- a/src/stateMachines/wifiNetworkConfiguration.ts
+++ b/src/stateMachines/wifiNetworkConfiguration.ts
@@ -12,7 +12,7 @@ import { devices } from '../devices.js'
 import { Error } from './error.js'
 import { Configurator } from '../Configurator.js'
 import { DbCreatorFactory } from '../factories/DbCreatorFactory.js'
-import { type CommonContext, invokeWsmanCall } from './common.js'
+import { type CommonContext, invokeWsmanCall, recordComponentResult, updateNetworkStatus } from './common.js'
 import { type WifiCredentials } from '../interfaces/ISecretManagerService.js'
 import { UNEXPECTED_PARSE_ERROR, DEFAULT_MAX_TCP_RETRANSMISSIONS } from '../utils/constants.js'
 import {
@@ -21,6 +21,11 @@ import {
   sendEnterpriseAssistantKeyPairResponse
 } from './enterpriseAssistant.js'
 import { RPSError } from '../utils/RPSError.js'
+
+/** Status string that drives the LocalProfileSync mode; shared by producer and consumer. */
+const WIRELESS_LOCAL_PROFILE_SYNC_STATUS = 'Wireless Only Local Profile Sync Configured'
+/** Component-facing detail for the sync-only case (drops the legacy "Wireless Only" prefix). */
+const LOCAL_PROFILE_SYNC_DETAILS = 'Local Profile Sync Configured'
 
 export interface WiFiConfigContext extends CommonContext {
   amtProfile: AMTConfiguration | null
@@ -330,20 +335,20 @@ export class WiFiConfiguration {
       },
       'Update Configuration Status': ({ context }) => {
         const { clientId, profilesAdded, profilesFailed, statusMessage, errorMessage } = context
-        const device = devices[clientId]
-        const networkStatus = device.status.Network
-        let message
-        if (errorMessage) {
-          message = errorMessage
-        } else if (profilesFailed) {
-          message =
-            profilesAdded != null
-              ? `Added ${profilesAdded} WiFi Profiles. Failed to add ${profilesFailed}`
-              : `Failed to add ${profilesFailed}`
-        } else {
-          message = statusMessage
-        }
-        device.status.Network = networkStatus ? `${networkStatus}. ${message}` : message
+        const { message, failed } = updateNetworkStatus({
+          clientId,
+          errorMessage,
+          statusMessage,
+          added: profilesAdded,
+          failedItems: profilesFailed,
+          itemLabel: 'WiFi Profiles'
+        })
+        const isLocalSync = !failed && message === WIRELESS_LOCAL_PROFILE_SYNC_STATUS
+        recordComponentResult(clientId, 'WirelessNetwork', {
+          Result: failed ? 'Failure' : 'Success',
+          Mode: isLocalSync ? 'LocalProfileSync' : undefined,
+          Details: isLocalSync ? LOCAL_PROFILE_SYNC_DETAILS : message
+        })
       },
       'Reset Retry Count': assign({ retryCount: () => 0 }),
       'Increment Retry Count': assign({ retryCount: ({ context, event }) => context.retryCount + 1 }),
@@ -739,7 +744,7 @@ export class WiFiConfiguration {
       },
       SUCCESS_SYNC_ONLY: {
         entry: [
-          assign({ statusMessage: () => 'Wireless Only Local Profile Sync Configured' }),
+          assign({ statusMessage: () => WIRELESS_LOCAL_PROFILE_SYNC_STATUS }),
           'Update Configuration Status'
         ],
         type: 'final'

--- a/src/stateMachines/wiredNetworkConfiguration.test.ts
+++ b/src/stateMachines/wiredNetworkConfiguration.test.ts
@@ -30,6 +30,7 @@ vi.mock('./common.js', async () => {
     invokeWsmanCall: invokeWsmanCallSpy,
     invokeEnterpriseAssistantCall: invokeEnterpriseAssistantCallSpy,
     processTLSTunnelResponse: vi.fn(),
+    recordComponentResult: actual.recordComponentResult,
     coalesceMessage,
     isDigestRealmValid,
     HttpResponseError
@@ -452,6 +453,10 @@ describe('Wired Network Configuration', () => {
               if (state.matches('SUCCESS') && currentStateIndex === flowStates.length) {
                 const status = devices[clientId].status.Network
                 expect(status).toEqual('Wired Network Configured')
+                expect(devices[clientId].status.Components?.WiredNetwork).toEqual({
+                  Result: 'Success',
+                  Details: 'Wired Network Configured'
+                })
                 resolve()
               }
             } catch (err) {
@@ -511,6 +516,10 @@ describe('Wired Network Configuration', () => {
               const expectedState: any = flowStates[currentStateIndex++]
               expect(state.matches(expectedState)).toBe(true)
               if (state.matches('FAILED') && currentStateIndex === flowStates.length) {
+                expect(devices[clientId].status.Components?.WiredNetwork).toEqual({
+                  Result: 'Failure',
+                  Details: 'Failed to get 8021x wired profile'
+                })
                 resolve()
               }
             } catch (err) {

--- a/src/stateMachines/wiredNetworkConfiguration.ts
+++ b/src/stateMachines/wiredNetworkConfiguration.ts
@@ -11,7 +11,7 @@ import { devices } from '../devices.js'
 import { Error } from './error.js'
 import { Configurator } from '../Configurator.js'
 import { DbCreatorFactory } from '../factories/DbCreatorFactory.js'
-import { type CommonContext, invokeWsmanCall } from './common.js'
+import { type CommonContext, invokeWsmanCall, recordComponentResult } from './common.js'
 import { UNEXPECTED_PARSE_ERROR } from '../utils/constants.js'
 import { Environment } from '../utils/Environment.js'
 import {
@@ -253,6 +253,13 @@ export class WiredConfiguration {
       'Update Configuration Status': ({ context }) => {
         const device = devices[context.clientId]
         device.status.Network = context.errorMessage ?? context.statusMessage
+        recordComponentResult(
+          context.clientId,
+          'WiredNetwork',
+          context.errorMessage
+            ? { Result: 'Failure', Details: context.errorMessage }
+            : { Result: 'Success', Details: context.statusMessage }
+        )
       }
     }
   }).createMachine({


### PR DESCRIPTION
Break the activation outcome into structured per-component results (Activation, WiredNetwork, WirelessNetwork, TLS, CIRAProxy, CIRAConnection) so operators get granular visibility into what succeeded or failed during the multi-minute provisioning window.

Each child state machine now records a {Result, Mode, Details, ErrorCode} entry into a new additive Status.Components object via a shared recordComponentResult helper, alongside the existing flat status strings. The result rides in the same WebSocket message field, so older RPC clients that don't understand Components simply ignore it. Recording never alters control flow: a component failure is captured for visibility but does not change the activation outcome.

802.1x reporting is intentionally deferred to a follow-up.

Refs #2665

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
