### PR TITLE
feat(activation): stream real-time provisioning progress to rpc-go

### DIFF
--- a/src/stateMachines/activation.test.ts
+++ b/src/stateMachines/activation.test.ts
@@ -29,6 +29,7 @@ import {
 } from './activation.js'
 
 const invokeWsmanCallSpy = vi.hoisted(() => vi.fn<any>())
+const sendProgressToDeviceSpy = vi.hoisted(() => vi.fn<any>())
 vi.mock('./common.js', async () => {
   const actual = await vi.importActual<typeof import('./common.js')>('./common.js')
   const { HttpResponseError, coalesceMessage, isDigestRealmValid } = actual
@@ -36,6 +37,7 @@ vi.mock('./common.js', async () => {
     invokeWsmanCall: invokeWsmanCallSpy,
     invokeEnterpriseAssistantCall: vi.fn(),
     processTLSTunnelResponse: vi.fn(),
+    sendProgressToDevice: sendProgressToDeviceSpy,
     HttpResponseError,
     isDigestRealmValid,
     coalesceMessage
@@ -825,10 +827,16 @@ describe('Activation State Machine', () => {
       expect(devices[clientId].ClientData.payload.modes).toBeDefined()
     })
 
-    it('should set activation status', () => {
+    it('should set activation status and emit "Activation completed" only once', () => {
       devices[context.clientId].status.Status = 'Admin control mode.'
+      devices[context.clientId].activationStatus = false
+      sendProgressToDeviceSpy.mockClear()
       activation.setActivationStatus({ context })
       expect(devices[clientId].activationStatus).toBeTruthy()
+      expect(sendProgressToDeviceSpy).toHaveBeenCalledWith(clientId, 'Activation completed')
+      // E2E TLS calls this again (CCM -> ACM upgrade); it must not emit a second time
+      activation.setActivationStatus({ context })
+      expect(sendProgressToDeviceSpy).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -894,6 +902,11 @@ describe('Activation State Machine', () => {
           if (state.matches('DELAYED_TRANSITION')) {
             vi.advanceTimersByTime(10000)
           } else if (state.matches('PROVISIONED') && currentStateIndex === flowStates.length) {
+            // progress fired at each milestone
+            expect(sendProgressToDeviceSpy).toHaveBeenCalledWith(clientId, 'Starting provisioning')
+            expect(sendProgressToDeviceSpy).toHaveBeenCalledWith(clientId, 'Clearing previous configuration')
+            expect(sendProgressToDeviceSpy).toHaveBeenCalledWith(clientId, 'Configuring network settings')
+            expect(sendProgressToDeviceSpy).toHaveBeenCalledWith(clientId, 'Configuring AMT features')
             resolve()
           }
         })

--- a/src/stateMachines/activation.ts
+++ b/src/stateMachines/activation.ts
@@ -25,7 +25,7 @@ import { DbCreatorFactory } from '../factories/DbCreatorFactory.js'
 import { AMTUserName, GATEWAY_TIMEOUT_ERROR, asArray } from '../utils/constants.js'
 import { CIRAConfiguration } from './ciraConfiguration.js'
 import { TLS } from './tls.js'
-import { type CommonContext, invokeWsmanCall, processTLSTunnelResponse } from './common.js'
+import { type CommonContext, invokeWsmanCall, processTLSTunnelResponse, sendProgressToDevice } from './common.js'
 import ClientResponseMsg from '../utils/ClientResponseMsg.js'
 import { Unconfiguration } from './unconfiguration.js'
 import { type DeviceCredentials } from '../interfaces/ISecretManagerService.js'
@@ -427,7 +427,12 @@ export class Activation {
   setActivationStatus({ context }): void {
     const clientObj = devices[context.clientId]
     this.logger.debug(`Device ${clientObj.uuid} activated in ${clientObj.status.Status}.`)
+    // Emit once: the E2E TLS flow activates (CCM) then upgrades (ACM), calling this twice.
+    const alreadyActivated = clientObj.activationStatus === true
     clientObj.activationStatus = true
+    if (!alreadyActivated) {
+      sendProgressToDevice(context.clientId, 'Activation completed')
+    }
     MqttProvider.publishEvent(
       'success',
       ['Activator', 'execute'],
@@ -1316,7 +1321,10 @@ export class Activation {
       'Send Message to Device': this.sendMessageToDevice.bind(this),
       'Get Provisioning CertObj': this.GetProvisioningCertObj.bind(this),
       'Compare Domain Cert Hashes': this.compareCertHashes.bind(this),
-      'Update AMT Credentials': this.updateCredentials.bind(this)
+      'Update AMT Credentials': this.updateCredentials.bind(this),
+      'Send Progress': ({ context }, params: { label: string }) => {
+        sendProgressToDevice(context.clientId, params.label)
+      }
     }
   }).createMachine({
     context: ({ input }) => ({
@@ -1370,6 +1378,7 @@ export class Activation {
         }
       },
       GET_AMT_PROFILE: {
+        entry: { type: 'Send Progress', params: { label: 'Starting provisioning' } },
         invoke: {
           src: 'getAMTProfile',
           input: ({ context }) => context,
@@ -1397,7 +1406,8 @@ export class Activation {
         always: [
           {
             guard: 'isActivated',
-            target: 'CHECK_TENANT_ACCESS'
+            target: 'CHECK_TENANT_ACCESS',
+            actions: { type: 'Send Progress', params: { label: 'Device already activated' } }
           },
           {
             guard: 'isTlsActivation',
@@ -2397,7 +2407,10 @@ export class Activation {
         }
       },
       UNCONFIGURATION: {
-        entry: sendTo('unconfiguration-machine', { type: 'REMOVECONFIG' }),
+        entry: [
+          { type: 'Send Progress', params: { label: 'Clearing previous configuration' } },
+          sendTo('unconfiguration-machine', { type: 'REMOVECONFIG' })
+        ],
         invoke: {
           src: 'unconfiguration',
           id: 'unconfiguration-machine',
@@ -2417,7 +2430,10 @@ export class Activation {
         }
       },
       NETWORK_CONFIGURATION: {
-        entry: sendTo('network-configuration-machine', { type: 'NETWORKCONFIGURATION' }),
+        entry: [
+          { type: 'Send Progress', params: { label: 'Configuring network settings' } },
+          sendTo('network-configuration-machine', { type: 'NETWORKCONFIGURATION' })
+        ],
         invoke: {
           src: 'networkConfiguration',
           id: 'network-configuration-machine',
@@ -2436,7 +2452,10 @@ export class Activation {
         }
       },
       FEATURES_CONFIGURATION: {
-        entry: sendTo('features-configuration-machine', { type: 'CONFIGURE_FEATURES' }),
+        entry: [
+          { type: 'Send Progress', params: { label: 'Configuring AMT features' } },
+          sendTo('features-configuration-machine', { type: 'CONFIGURE_FEATURES' })
+        ],
         invoke: {
           src: 'featuresConfiguration',
           id: 'features-configuration-machine',
@@ -2474,7 +2493,10 @@ export class Activation {
         }
       },
       CIRA: {
-        entry: sendTo('cira-machine', { type: 'CONFIGURE_CIRA' }),
+        entry: [
+          { type: 'Send Progress', params: { label: 'Configuring CIRA remote access' } },
+          sendTo('cira-machine', { type: 'CONFIGURE_CIRA' })
+        ],
         invoke: {
           src: 'cira',
           id: 'cira-machine',
@@ -2502,7 +2524,10 @@ export class Activation {
         }
       },
       TLS: {
-        entry: sendTo('tls-machine', { type: 'CONFIGURE_TLS' }),
+        entry: [
+          { type: 'Send Progress', params: { label: 'Configuring TLS' } },
+          sendTo('tls-machine', { type: 'CONFIGURE_TLS' })
+        ],
         invoke: {
           src: 'tls',
           id: 'tls-machine',

--- a/src/stateMachines/ciraConfiguration.test.ts
+++ b/src/stateMachines/ciraConfiguration.test.ts
@@ -29,6 +29,7 @@ vi.mock('./common.js', async () => {
     invokeWsmanCall: invokeWsmanCallSpy,
     invokeEnterpriseAssistantCall: vi.fn(),
     processTLSTunnelResponse: vi.fn(),
+    sendProgressToDevice: vi.fn(),
     HttpResponseError,
     isDigestRealmValid,
     coalesceMessage

--- a/src/stateMachines/ciraConfiguration.ts
+++ b/src/stateMachines/ciraConfiguration.ts
@@ -22,7 +22,7 @@ import { type DeviceCredentials } from '../interfaces/ISecretManagerService.js'
 import { type AMTConfiguration } from '../models/index.js'
 import { randomUUID } from 'node:crypto'
 import { Error } from './error.js'
-import { type CommonContext, invokeWsmanCall } from './common.js'
+import { type CommonContext, invokeWsmanCall, sendProgressToDevice } from './common.js'
 
 export interface CIRAConfigContext extends CommonContext {
   status: 'success' | 'error' | 'wsman' | 'heartbeat_request'
@@ -315,6 +315,11 @@ export class CIRAConfiguration {
     actions: {
       'Update Configuration Status': ({ context, event }) => {
         devices[context.clientId].status.CIRAConnection = context.statusMessage
+        if (context.statusMessage === 'Configured') {
+          sendProgressToDevice(context.clientId, 'CIRA configuration completed')
+        } else {
+          sendProgressToDevice(context.clientId, `CIRA configuration failed: ${context.statusMessage}`)
+        }
       },
       'Reset Unauth Count': ({ context, event }) => {
         devices[context.clientId].unauthCount = 0

--- a/src/stateMachines/common.test.ts
+++ b/src/stateMachines/common.test.ts
@@ -18,7 +18,8 @@ import {
   invokeEnterpriseAssistantCall,
   invokeEnterpriseAssistantCallInternal,
   invokeWsmanCall,
-  coalesceMessage
+  coalesceMessage,
+  sendProgressToDevice
 } from './common.js'
 
 Environment.Config = config
@@ -44,6 +45,11 @@ describe('Common', () => {
       ClientSocket: {
         send: vi.fn()
       },
+      ClientData: {
+        payload: {
+          progressSupported: true
+        }
+      },
       connectionParams: {
         guid: clientId,
         port: 16992,
@@ -66,6 +72,27 @@ describe('Common', () => {
     Environment.Config.wsman_max_attempts = originalWsmanMaxAttempts
     vi.runAllTicks()
     vi.useRealTimers()
+  })
+
+  it('should send a progress message as a plain-text progress frame', () => {
+    sendProgressToDevice(clientId, 'Configuring network settings')
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const sent = JSON.parse(sendSpy.mock.calls[0][0])
+    expect(sent.method).toEqual('progress')
+    expect(sent.message).toEqual('Configuring network settings')
+    // Progress carries its text in `message`, not an encoded payload.
+    expect(sent.payload).toBeNull()
+  })
+  it('should not send progress when the client did not advertise progressSupported', () => {
+    devices[clientId].ClientData.payload.progressSupported = undefined
+    sendProgressToDevice(clientId, 'Configuring network settings')
+    expect(sendSpy).not.toHaveBeenCalled()
+  })
+  it('should not throw when the device has no client socket', () => {
+    const orphanId = randomUUID()
+    expect(() => {
+      sendProgressToDevice(orphanId, 'Starting provisioning')
+    }).not.toThrow()
   })
 
   it('should send a WSMan message once with successful reply', async () => {

--- a/src/stateMachines/common.ts
+++ b/src/stateMachines/common.ts
@@ -25,6 +25,26 @@ import { parseChunkedMessage } from '../utils/parseChunkedMessage.js'
 import { TLSTunnelManager } from '../TLSTunnelManager.js'
 
 const invokeWsmanLogger = new Logger('invokeWsmanCall')
+const progressLogger = new Logger('sendProgressToDevice')
+
+// Best-effort progress note to rpc-go — emitted both at phase boundaries (state entry)
+// and for per-item milestones (e.g. each WiFi profile / proxy add) via transition actions.
+// Gated on the client advertising `progressSupported`; failures are swallowed.
+export const sendProgressToDevice = (clientId: string, label: string): void => {
+  try {
+    const clientObj = devices[clientId]
+    if (clientObj?.ClientSocket == null) {
+      return
+    }
+    if (clientObj.ClientData?.payload?.progressSupported !== true) {
+      return
+    }
+    const responseMessage = ClientResponseMsg.get(clientId, null, 'progress', 'ok', label)
+    clientObj.ClientSocket.send(JSON.stringify(responseMessage))
+  } catch (err) {
+    progressLogger.warn(`Failed to send progress to device ${clientId}: ${(err as Error).message}`)
+  }
+}
 
 /**
  * If retries is more than 0, will resend the message

--- a/src/stateMachines/featuresConfiguration.test.ts
+++ b/src/stateMachines/featuresConfiguration.test.ts
@@ -21,10 +21,12 @@ import { devices } from '../devices.js'
 import { HttpHandler } from '../HttpHandler.js'
 import { type MachineImplementationsSimplified, createActor, fromPromise } from 'xstate'
 import { AMT, CIM, IPS } from '@device-management-toolkit/wsman-messages'
+import { sendProgressToDevice } from './common.js'
 
 const invokeWsmanCallSpy = vi.hoisted(() => vi.fn<any>())
 vi.mock('./common.js', () => ({
-  invokeWsmanCall: invokeWsmanCallSpy
+  invokeWsmanCall: invokeWsmanCallSpy,
+  sendProgressToDevice: vi.fn()
 }))
 
 const { FeaturesConfiguration } = await import('./featuresConfiguration.js')
@@ -140,6 +142,11 @@ describe('Features State Machine', () => {
             const expectedState: any = flowStates[currentStateIndex++]
             expect(state.matches(expectedState)).toBe(true)
             if (state.matches('SUCCESS') && currentStateIndex === flowStates.length) {
+              // Progress reports which features were configured (issue #2665)
+              expect(sendProgressToDevice).toHaveBeenCalledWith(
+                clientId,
+                'AMT features completed: KVM, SOL, IDER (User Consent: All)'
+              )
               resolve()
             }
           } catch (err) {

--- a/src/stateMachines/featuresConfiguration.ts
+++ b/src/stateMachines/featuresConfiguration.ts
@@ -12,7 +12,7 @@ import {
   mapAMTUserConsent,
   AMTUserConsent
 } from '../models/index.js'
-import { type CommonContext, invokeWsmanCall } from './common.js'
+import { type CommonContext, invokeWsmanCall, sendProgressToDevice } from './common.js'
 
 export interface FeatureContext extends CommonContext {
   isRedirectionChanged: boolean
@@ -306,14 +306,25 @@ export class FeaturesConfiguration {
         }
       },
       SUCCESS: {
-        entry: () => {
+        entry: ({ context }) => {
           this.logger.info('AMT Features Configuration success')
+          const cfg = context.amtConfiguration
+          const enabled: string[] = []
+          if (cfg?.kvmEnabled) enabled.push('KVM')
+          if (cfg?.solEnabled) enabled.push('SOL')
+          if (cfg?.iderEnabled) enabled.push('IDER')
+          const userConsent = cfg?.userConsent != null ? cfg.userConsent : AMTUserConsent.ALL
+          let detail = 'AMT features completed'
+          if (enabled.length > 0) detail += `: ${enabled.join(', ')}`
+          detail += ` (User Consent: ${userConsent})`
+          sendProgressToDevice(context.clientId, detail)
         },
         type: 'final'
       },
       FAILED: {
         entry: ({ context }) => {
           this.logger.error(`AMT Features Configuration failed: ${context.statusMessage}`)
+          sendProgressToDevice(context.clientId, `AMT features configuration failed: ${context.statusMessage}`)
         },
         type: 'final'
       }

--- a/src/stateMachines/networkConfiguration.test.ts
+++ b/src/stateMachines/networkConfiguration.test.ts
@@ -29,6 +29,9 @@ vi.mock('./common.js', async () => {
     invokeWsmanCall: invokeWsmanCallSpy,
     invokeEnterpriseAssistantCall: invokeEnterpriseAssistantCallSpy,
     processTLSTunnelResponse: vi.fn(),
+    // wired/wifi/proxy machines call this during their flows; mock it so the
+    // partial common.js mock still provides the export they import.
+    sendProgressToDevice: vi.fn(),
     HttpResponseError,
     isDigestRealmValid,
     coalesceMessage

--- a/src/stateMachines/proxyConfiguration.test.ts
+++ b/src/stateMachines/proxyConfiguration.test.ts
@@ -17,6 +17,7 @@ import {
 import { type MachineImplementationsSimplified, createActor, fromPromise } from 'xstate'
 import { HttpHandler } from '../HttpHandler.js'
 import { IPS } from '@device-management-toolkit/wsman-messages'
+import * as common from './common.js'
 
 const { ProxyConfiguration } = await import('./proxyConfiguration.js')
 const clientId = randomUUID()
@@ -115,6 +116,7 @@ describe('Proxy Configuration State Machine', () => {
 
     it('should add a Proxy config to AMT.', () =>
       new Promise<void>((resolve, reject) => {
+        const progressSpy = vi.spyOn(common, 'sendProgressToDevice').mockImplementation(() => {})
         context.proxyConfig = {
           proxyName: 'proxy1',
           address: 'www.vprodemo.com',
@@ -145,6 +147,62 @@ describe('Proxy Configuration State Machine', () => {
               if (state.matches('SUCCESS') && currentStateIndex === flowStates.length) {
                 const status = devices[clientId].status.Network
                 expect(status).toEqual('Initial. Proxy Configured')
+                // Phase start + completion progress lines (issue #2665)
+                expect(progressSpy).toHaveBeenCalledWith(clientId, 'Configuring proxies')
+                expect(progressSpy).toHaveBeenCalledWith(clientId, 'Proxies configuration completed')
+                progressSpy.mockRestore()
+                service.stop()
+                resolve()
+              }
+            } catch (err) {
+              reject(err)
+            }
+          },
+          error: (err) => {
+            reject(err)
+          }
+        })
+        service.start()
+        service.send({ type: 'PROXYCONFIG', clientId })
+      }))
+
+    it('emits a per-proxy "Failed to add" progress line with the AMT ReturnValue', () =>
+      new Promise<void>((resolve, reject) => {
+        const progressSpy = vi.spyOn(common, 'sendProgressToDevice').mockImplementation(() => {})
+        context.proxyConfig = {
+          proxyName: 'proxy1',
+          address: 'www.vprodemo.com',
+          infoFormat: 201,
+          port: 900,
+          networkDnsSuffix: 'intel.com'
+        }
+        // AMT accepts the call but rejects the proxy (non-zero ReturnValue)
+        config.actors!.addProxyConfigs = fromPromise(
+          async () => await Promise.resolve({ Envelope: { Body: { AddProxyAccessPoint_OUTPUT: { ReturnValue: 1 } } } })
+        )
+        context.proxyConfigName = 'proxy1'
+        context.proxyConfigsCount = 1
+        config.guards = { isMoreProxyConfigs: () => false, isProxyConfigsExist: () => true }
+
+        const machine = proxyConfiguration.machine.provide(config)
+        const flowStates = [
+          'ACTIVATION',
+          'GET_PROXY_CONFIG',
+          'ADD_PROXY_CONFIGS',
+          'SUCCESS'
+        ]
+        const service = createActor(machine, { input: context })
+        service.subscribe({
+          next: (state) => {
+            try {
+              const expectedState: any = flowStates[currentStateIndex++]
+              expect(state.matches(expectedState)).toBe(true)
+              if (state.matches('SUCCESS') && currentStateIndex === flowStates.length) {
+                expect(progressSpy).toHaveBeenCalledWith(
+                  clientId,
+                  'Failed to add proxy configuration proxy1 (ReturnValue 1)'
+                )
+                progressSpy.mockRestore()
                 service.stop()
                 resolve()
               }

--- a/src/stateMachines/proxyConfiguration.ts
+++ b/src/stateMachines/proxyConfiguration.ts
@@ -13,7 +13,7 @@ import { devices } from '../devices.js'
 import { Error } from './error.js'
 import { Configurator } from '../Configurator.js'
 import { DbCreatorFactory } from '../factories/DbCreatorFactory.js'
-import { type CommonContext, invokeWsmanCall } from './common.js'
+import { type CommonContext, invokeWsmanCall, sendProgressToDevice } from './common.js'
 import { UNEXPECTED_PARSE_ERROR } from '../utils/constants.js'
 
 export interface ProxyConfigContext extends CommonContext {
@@ -115,6 +115,14 @@ export class ProxyConfiguration {
           message = statusMessage
         }
         device.status.Network = networkStatus ? `${networkStatus}. ${message}` : message
+        // Phase completion line — only when proxies were actually processed (something added or failed).
+        if (proxyConfigsAdded != null || proxyConfigsFailed != null || errorMessage) {
+          if (errorMessage || proxyConfigsFailed) {
+            sendProgressToDevice(clientId, `Proxies configuration failed: ${message}`)
+          } else {
+            sendProgressToDevice(clientId, 'Proxies configuration completed')
+          }
+        }
       },
       'Reset Retry Count': assign({ retryCount: () => 0 }),
       'Increment Retry Count': assign({ retryCount: ({ context }) => context.retryCount + 1 }),
@@ -141,7 +149,19 @@ export class ProxyConfiguration {
             return context.proxyConfigFailed
           }
         }
-      })
+      }),
+      'Send Proxy Progress': ({ context, event }) => {
+        // mirror 'Check Return Value' — keep in sync
+        const returnValue = event.output?.Envelope?.Body?.AddProxyAccessPoint_OUTPUT?.ReturnValue
+        if (returnValue === 0) {
+          sendProgressToDevice(context.clientId, `Added proxy configuration ${context.proxyConfigName}`)
+        } else {
+          sendProgressToDevice(
+            context.clientId,
+            `Failed to add proxy configuration ${context.proxyConfigName} (ReturnValue ${returnValue})`
+          )
+        }
+      }
     }
   }).createMachine({
     /** @xstate-layout N4IgpgJg5mDOIC5QAcBOB7AHgTwLQGN0A7AMwEsoBXVAQwBczjcBbG-ACzKLADoBBAMIAVAJIA1PqIDyAOQDEABQBKUgBoBNAbIBiIgOIBtAAwBdRCnSwyDYuZCZEAFgBMARh4BOIwDZnAZkcADi9nUIBWMIAaEGxEQPcwoyNXIwB2ZyNQj0cw1IBfPOi0LDxCUgpqekYiFjZObh4BAAkAUQEAaQB9bSklTuU1dU6tGV09AGU5YzMkEGRLa2q7BwQU13dA50CjD2zvR1S-V29o2NXXDx5Uoz9-Vz9vLw8-MOcCoowcAmJyKlobGqsDhcXjNNpdHp9AYaYY6fSTAyuGYWKwA5aIIynDHvOafUo-Cr-aq1YENPQtIT9FQwkZjOQQYi8LgAN3QAGteDA6Lhil8yr9pnZ5qilrMVmtAld4hcPIlUtlUicYohnKkwjxvGFvA9HF5goEDWEcbz8eU-lUmED6rxyZToUNafo5GBUBhUDxkAAbegkdCoZg8Lk8vHfM2C2bCxa2MWIVy5VI8HJHC7+baOIxRZUIZyvTzODzbHP7VyBVLHY0h-mEi2Auog-gAEQbVMGsNG8PpjJ4LPZvBoEAgwZKod+sHDKKjRHRCBc7i8vgCwUy4UzZyCCcCYWyN1CLlSavyhVxw6r5oBJOtjeb9rbY0mLrdHu9dF9-p4-cHJpHFDHpiFCzRGMZzcTwfH8IIQhXLEED8bJQO1B51jVRJvArE8CTPYkrXrMEOk6PgmxbGk4QmTolBacYFFkcYWimP8IwA0VQHFZINi2HY9gOI4lTXC4eDcXxXFVe5HBLRw0L5DDKnPbCGlwroCOvakHRI8YyIoqiZBoqYkX-EVo2Y2NWJ4TZtl2Rx9kOY5oIs9UBIuW5ZTSTUjRxIh0AgOAhUrKSiUtOtuD0ydp1wIJoNwUseGObxvFSQJROOWC-Ak01fmkrCAt4QRRAkaQZCCwDDOzbwEjjbwdlCG4XjCPxoKQzwavuJJci1DJXI+dCzXS-zSVBVo8MhIiVPbCYCqY+xEG8A0otLGq3F2NxHDq1wE1lI4-GatVfAzFLv0wnrL1tIbb30MaDIm1Z-GceCc2alaImgnN3DK9b9RyMJAl209utrXqr2Ox1RoY-SpyAlxHrLfj4luRIjG2Hd2uPSSur837L3k-DCJvQG1PIyjqJaM7QaK-ZvB4AI-EVOGvBeJasxcPwTM2DxXEcDbNnzRGv2+1GL3rbQ+BEAAZFoGyJ6cVq8fiKdLLxdUpjw6os+CAkeCyPEeGqvt8ms+YacYAFUBAECjxnFoChNuG7YbCe7VycHMrmODIpvuUIHgKAogA */
@@ -181,6 +201,12 @@ export class ProxyConfiguration {
         ]
       },
       GET_PROXY_CONFIG: {
+        // Emit the phase start once, before the first proxy is fetched.
+        entry: ({ context }) => {
+          if (context.proxyConfigsCount === 0) {
+            sendProgressToDevice(context.clientId, 'Configuring proxies')
+          }
+        },
         invoke: {
           src: 'getProxyConfig',
           input: ({ context }) => context,
@@ -200,16 +226,20 @@ export class ProxyConfiguration {
           input: ({ context }) => context,
           id: 'add-proxy-configs',
           onDone: {
-            actions: 'Check Return Value',
+            actions: ['Check Return Value', 'Send Proxy Progress'],
             target: 'CHECK_ADD_PROXY_CONFIGS_RESPONSE'
           },
           onError: {
-            actions: assign({
-              proxyConfigFailed: ({ context }) =>
-                context.proxyConfigFailed == null
-                  ? `${context.proxyConfigName}`
-                  : `${context.proxyConfigFailed}, ${context.proxyConfigName}`
-            }),
+            actions: [
+              assign({
+                proxyConfigFailed: ({ context }) =>
+                  context.proxyConfigFailed == null
+                    ? `${context.proxyConfigName}`
+                    : `${context.proxyConfigFailed}, ${context.proxyConfigName}`
+              }),
+              ({ context }) =>
+                sendProgressToDevice(context.clientId, `Failed to add proxy configuration ${context.proxyConfigName}`)
+            ],
             target: 'CHECK_ADD_PROXY_CONFIGS_RESPONSE'
           }
         }

--- a/src/stateMachines/tls.test.ts
+++ b/src/stateMachines/tls.test.ts
@@ -19,7 +19,8 @@ const invokeWsmanCallSpy = vi.hoisted(() => vi.fn<any>())
 const invokeEnterpriseAssistantCallSpy = vi.hoisted(() => vi.fn<any>())
 vi.mock('./common.js', () => ({
   invokeWsmanCall: invokeWsmanCallSpy,
-  invokeEnterpriseAssistantCall: invokeEnterpriseAssistantCallSpy
+  invokeEnterpriseAssistantCall: invokeEnterpriseAssistantCallSpy,
+  sendProgressToDevice: vi.fn()
 }))
 
 const { TLS } = await import('./tls.js')

--- a/src/stateMachines/tls.ts
+++ b/src/stateMachines/tls.ts
@@ -22,7 +22,7 @@ import {
   initiateCertRequest,
   sendEnterpriseAssistantKeyPairResponse
 } from './enterpriseAssistant.js'
-import { type CommonContext, invokeWsmanCall } from './common.js'
+import { type CommonContext, invokeWsmanCall, sendProgressToDevice } from './common.js'
 
 export interface TLSContext extends CommonContext {
   amtProfile: AMTConfiguration | null
@@ -233,8 +233,11 @@ export class TLS {
   updateConfigurationStatus({ context }: { context: TLSContext }): void {
     if (context.status === 'success') {
       devices[context.clientId].status.TLSConfiguration = context.statusMessage
+      sendProgressToDevice(context.clientId, 'TLS configuration completed')
     } else if (context.status === 'error') {
-      devices[context.clientId].status.TLSConfiguration = context.errorMessage !== '' ? context.errorMessage : 'Failed'
+      const details = context.errorMessage !== '' ? context.errorMessage : 'Failed'
+      devices[context.clientId].status.TLSConfiguration = details
+      sendProgressToDevice(context.clientId, `TLS configuration failed: ${details}`)
     }
   }
 

--- a/src/stateMachines/wifiNetworkConfiguration.test.ts
+++ b/src/stateMachines/wifiNetworkConfiguration.test.ts
@@ -22,6 +22,7 @@ import { HttpResponseError, coalesceMessage, isDigestRealmValid } from './common
 
 const invokeWsmanCallSpy = vi.hoisted(() => vi.fn<any>())
 const invokeEnterpriseAssistantCallSpy = vi.hoisted(() => vi.fn<any>())
+const sendProgressToDeviceSpy = vi.hoisted(() => vi.fn<any>())
 vi.mock('./common.js', async () => {
   const actual = await vi.importActual<typeof import('./common.js')>('./common.js')
   const { HttpResponseError, coalesceMessage, isDigestRealmValid } = actual
@@ -29,6 +30,7 @@ vi.mock('./common.js', async () => {
     invokeWsmanCall: invokeWsmanCallSpy,
     invokeEnterpriseAssistantCall: invokeEnterpriseAssistantCallSpy,
     processTLSTunnelResponse: vi.fn(),
+    sendProgressToDevice: sendProgressToDeviceSpy,
     HttpResponseError,
     isDigestRealmValid,
     coalesceMessage
@@ -51,6 +53,7 @@ describe('WiFi Network Configuration', () => {
     vi.clearAllMocks()
     invokeWsmanCallSpy.mockClear()
     invokeEnterpriseAssistantCallSpy.mockClear()
+    sendProgressToDeviceSpy.mockClear()
     wifiProfile = {
       profileName: 'test-profile',
       authenticationMethod: 5,
@@ -881,6 +884,11 @@ describe('WiFi Network Configuration', () => {
               if (state.matches('SUCCESS') && currentStateIndex === flowStates.length) {
                 const status = devices[clientId].status.Network
                 expect(status).toEqual('Wired Network Configured. Wireless Configured')
+                // emits on successful add (ReturnValue 0)
+                expect(sendProgressToDeviceSpy).toHaveBeenCalledWith(
+                  clientId,
+                  'Added wireless profile unsupportedEncryption'
+                )
                 resolve()
               }
             } catch (err) {
@@ -1110,6 +1118,21 @@ describe('WiFi Network Configuration', () => {
               if (state.matches('SUCCESS') && currentStateIndex === flowStates.length) {
                 const status = devices[clientId].status.Network
                 expect(status).toEqual('Wired Network Configured. Failed to add profile5')
+                // no per-profile "Added" emit on failed add (ReturnValue 1) ...
+                expect(sendProgressToDeviceSpy).not.toHaveBeenCalledWith(
+                  clientId,
+                  expect.stringContaining('Added wireless profile')
+                )
+                // ... a per-profile "Failed to add" emit (with the AMT ReturnValue) is sent instead ...
+                expect(sendProgressToDeviceSpy).toHaveBeenCalledWith(
+                  clientId,
+                  'Failed to add wireless profile profile5 (ReturnValue 1)'
+                )
+                // ... and the final failure summary is emitted
+                expect(sendProgressToDeviceSpy).toHaveBeenCalledWith(
+                  clientId,
+                  'Wireless network configuration failed: Failed to add profile5'
+                )
                 resolve()
               }
             } catch (err) {

--- a/src/stateMachines/wifiNetworkConfiguration.ts
+++ b/src/stateMachines/wifiNetworkConfiguration.ts
@@ -12,7 +12,7 @@ import { devices } from '../devices.js'
 import { Error } from './error.js'
 import { Configurator } from '../Configurator.js'
 import { DbCreatorFactory } from '../factories/DbCreatorFactory.js'
-import { type CommonContext, invokeWsmanCall } from './common.js'
+import { type CommonContext, invokeWsmanCall, sendProgressToDevice } from './common.js'
 import { type WifiCredentials } from '../interfaces/ISecretManagerService.js'
 import { UNEXPECTED_PARSE_ERROR, DEFAULT_MAX_TCP_RETRANSMISSIONS } from '../utils/constants.js'
 import {
@@ -344,6 +344,26 @@ export class WiFiConfiguration {
           message = statusMessage
         }
         device.status.Network = networkStatus ? `${networkStatus}. ${message}` : message
+        if (errorMessage || profilesFailed) {
+          sendProgressToDevice(clientId, `Wireless network configuration failed: ${message}`)
+        } else {
+          sendProgressToDevice(clientId, 'Wireless network configuration completed')
+        }
+      },
+      'Send WiFi Profile Progress': ({ context, event }) => {
+        // mirror 'Check Return Value' — keep in sync
+        const returnValue = event.output?.Envelope?.Body?.AddWiFiSettings_OUTPUT?.ReturnValue
+        // Note 802.1x per profile (wifi can mix PSK and 802.1x profiles).
+        // Truthy check, not != null — an empty profile name must not be labeled 802.1x.
+        const suffix = context.wifiProfile?.ieee8021xProfileName ? ' (802.1x)' : ''
+        if (returnValue === 0) {
+          sendProgressToDevice(context.clientId, `Added wireless profile ${context.wifiProfileName}${suffix}`)
+        } else {
+          sendProgressToDevice(
+            context.clientId,
+            `Failed to add wireless profile ${context.wifiProfileName}${suffix} (ReturnValue ${returnValue})`
+          )
+        }
       },
       'Reset Retry Count': assign({ retryCount: () => 0 }),
       'Increment Retry Count': assign({ retryCount: ({ context, event }) => context.retryCount + 1 }),
@@ -690,16 +710,20 @@ export class WiFiConfiguration {
           input: ({ context }) => context,
           id: 'add-wifi-settings',
           onDone: {
-            actions: 'Check Return Value',
+            actions: ['Check Return Value', 'Send WiFi Profile Progress'],
             target: 'CHECK_ADD_WIFI_SETTINGS_RESPONSE'
           },
           onError: {
-            actions: assign({
-              profilesFailed: ({ context }) =>
-                context.profilesFailed == null
-                  ? `${context.wifiProfileName}`
-                  : `${context.profilesFailed}, ${context.wifiProfileName}`
-            }),
+            actions: [
+              assign({
+                profilesFailed: ({ context }) =>
+                  context.profilesFailed == null
+                    ? `${context.wifiProfileName}`
+                    : `${context.profilesFailed}, ${context.wifiProfileName}`
+              }),
+              ({ context }) =>
+                sendProgressToDevice(context.clientId, `Failed to add wireless profile ${context.wifiProfileName}`)
+            ],
             target: 'CHECK_ADD_WIFI_SETTINGS_RESPONSE'
           }
         }

--- a/src/stateMachines/wiredNetworkConfiguration.test.ts
+++ b/src/stateMachines/wiredNetworkConfiguration.test.ts
@@ -30,6 +30,7 @@ vi.mock('./common.js', async () => {
     invokeWsmanCall: invokeWsmanCallSpy,
     invokeEnterpriseAssistantCall: invokeEnterpriseAssistantCallSpy,
     processTLSTunnelResponse: vi.fn(),
+    sendProgressToDevice: vi.fn(),
     coalesceMessage,
     isDigestRealmValid,
     HttpResponseError

--- a/src/stateMachines/wiredNetworkConfiguration.ts
+++ b/src/stateMachines/wiredNetworkConfiguration.ts
@@ -11,7 +11,7 @@ import { devices } from '../devices.js'
 import { Error } from './error.js'
 import { Configurator } from '../Configurator.js'
 import { DbCreatorFactory } from '../factories/DbCreatorFactory.js'
-import { type CommonContext, invokeWsmanCall } from './common.js'
+import { type CommonContext, invokeWsmanCall, sendProgressToDevice } from './common.js'
 import { UNEXPECTED_PARSE_ERROR } from '../utils/constants.js'
 import { Environment } from '../utils/Environment.js'
 import {
@@ -253,6 +253,11 @@ export class WiredConfiguration {
       'Update Configuration Status': ({ context }) => {
         const device = devices[context.clientId]
         device.status.Network = context.errorMessage ?? context.statusMessage
+        if (context.errorMessage) {
+          sendProgressToDevice(context.clientId, `Wired network configuration failed: ${context.errorMessage}`)
+        } else {
+          sendProgressToDevice(context.clientId, 'Wired network configuration completed')
+        }
       }
     }
   }).createMachine({

--- a/src/utils/ClientResponseMsg.ts
+++ b/src/utils/ClientResponseMsg.ts
@@ -17,7 +17,7 @@ export default {
   get(
     clientId: string,
     payload: string | null,
-    method: 'error' | 'wsman' | 'success' | 'heartbeat_request' | 'tls_data' | 'port_switch',
+    method: 'error' | 'wsman' | 'success' | 'heartbeat_request' | 'tls_data' | 'port_switch' | 'progress',
     status: 'failed' | 'success' | 'ok' | 'heartbeat',
     message = ''
   ): ClientMsg {


### PR DESCRIPTION
Activation can take up to ~3 minutes during which the operator has little visibility into what step is running. Emit lightweight, human-readable progress notifications from the activation flow so rpc-go can surface them on the CLI.

A new fire-and-forget `progress` WS method carries plain text in the message field. Sends are best-effort so a failure never affects the activation outcome, and are gated on the client advertising `progressSupported` in its initial payload — older rpc-go never receives a progress frame, keeping mixed-version deployments safe.

Progress is emitted at state-machine boundaries (provisioning start, network, features, CIRA, TLS) and at the "wireless profile added" milestone, all via state `entry` actions so no transition/guard routing changes — the E2E TLS branch logic is untouched.

Refs device-management-toolkit/rps#2665

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
