### PR TITLE
fix: dedupe wifi/proxy added & failed status lists

### DIFF
--- a/src/stateMachines/proxyConfiguration.ts
+++ b/src/stateMachines/proxyConfiguration.ts
@@ -14,6 +14,7 @@ import { Error } from './error.js'
 import { Configurator } from '../Configurator.js'
 import { DbCreatorFactory } from '../factories/DbCreatorFactory.js'
 import { type CommonContext, invokeWsmanCall } from './common.js'
+import { addUnique, removeItem, addFailure } from '../utils/statusList.js'
 import { UNEXPECTED_PARSE_ERROR } from '../utils/constants.js'
 
 export interface ProxyConfigContext extends CommonContext {
@@ -119,28 +120,14 @@ export class ProxyConfiguration {
       'Reset Retry Count': assign({ retryCount: () => 0 }),
       'Increment Retry Count': assign({ retryCount: ({ context }) => context.retryCount + 1 }),
       'Check Return Value': assign({
-        proxyConfigAdded: ({ context, event }) => {
-          if (event.output.Envelope?.Body?.AddProxyAccessPoint_OUTPUT?.ReturnValue === 0) {
-            if (context.proxyConfigAdded == null) {
-              return `${context.proxyConfigName}`
-            } else {
-              return `${context.proxyConfigAdded}, ${context.proxyConfigName}`
-            }
-          } else {
-            return context.proxyConfigAdded
-          }
-        },
-        proxyConfigFailed: ({ context, event }) => {
-          if (event.output.Envelope?.Body?.AddProxyAccessPoint_OUTPUT?.ReturnValue !== 0) {
-            if (context.proxyConfigFailed == null) {
-              return `${context.proxyConfigName}`
-            } else {
-              return `${context.proxyConfigFailed}, ${context.proxyConfigName}`
-            }
-          } else {
-            return context.proxyConfigFailed
-          }
-        }
+        proxyConfigAdded: ({ context, event }) =>
+          event.output.Envelope?.Body?.AddProxyAccessPoint_OUTPUT?.ReturnValue === 0
+            ? addUnique(context.proxyConfigAdded, context.proxyConfigName)
+            : context.proxyConfigAdded,
+        proxyConfigFailed: ({ context, event }) =>
+          event.output.Envelope?.Body?.AddProxyAccessPoint_OUTPUT?.ReturnValue === 0
+            ? removeItem(context.proxyConfigFailed, context.proxyConfigName)
+            : addFailure(context.proxyConfigFailed, context.proxyConfigAdded, context.proxyConfigName)
       })
     }
   }).createMachine({
@@ -162,7 +149,11 @@ export class ProxyConfiguration {
         on: {
           PROXYCONFIG: {
             actions: [
-              assign({ proxyConfigsCount: () => 0 }),
+              assign({
+                proxyConfigsCount: () => 0,
+                proxyConfigAdded: () => undefined,
+                proxyConfigFailed: () => undefined
+              }),
               'Reset Retry Count'
             ],
             target: 'CHECK_FOR_PROXY_CONFIGS'
@@ -206,9 +197,7 @@ export class ProxyConfiguration {
           onError: {
             actions: assign({
               proxyConfigFailed: ({ context }) =>
-                context.proxyConfigFailed == null
-                  ? `${context.proxyConfigName}`
-                  : `${context.proxyConfigFailed}, ${context.proxyConfigName}`
+                addFailure(context.proxyConfigFailed, context.proxyConfigAdded, context.proxyConfigName)
             }),
             target: 'CHECK_ADD_PROXY_CONFIGS_RESPONSE'
           }

--- a/src/stateMachines/wifiNetworkConfiguration.ts
+++ b/src/stateMachines/wifiNetworkConfiguration.ts
@@ -13,6 +13,7 @@ import { Error } from './error.js'
 import { Configurator } from '../Configurator.js'
 import { DbCreatorFactory } from '../factories/DbCreatorFactory.js'
 import { type CommonContext, invokeWsmanCall } from './common.js'
+import { addUnique, removeItem, addFailure } from '../utils/statusList.js'
 import { type WifiCredentials } from '../interfaces/ISecretManagerService.js'
 import { UNEXPECTED_PARSE_ERROR, DEFAULT_MAX_TCP_RETRANSMISSIONS } from '../utils/constants.js'
 import {
@@ -348,28 +349,14 @@ export class WiFiConfiguration {
       'Reset Retry Count': assign({ retryCount: () => 0 }),
       'Increment Retry Count': assign({ retryCount: ({ context, event }) => context.retryCount + 1 }),
       'Check Return Value': assign({
-        profilesAdded: ({ context, event }) => {
-          if (event.output.Envelope?.Body?.AddWiFiSettings_OUTPUT?.ReturnValue === 0) {
-            if (context.profilesAdded == null) {
-              return `${context.wifiProfileName}`
-            } else {
-              return `${context.profilesAdded}, ${context.wifiProfileName}`
-            }
-          } else {
-            return context.profilesAdded
-          }
-        },
-        profilesFailed: ({ context, event }) => {
-          if (event.output.Envelope?.Body?.AddWiFiSettings_OUTPUT?.ReturnValue !== 0) {
-            if (context.profilesFailed == null) {
-              return `${context.wifiProfileName}`
-            } else {
-              return `${context.profilesFailed}, ${context.wifiProfileName}`
-            }
-          } else {
-            return context.profilesFailed
-          }
-        }
+        profilesAdded: ({ context, event }) =>
+          event.output.Envelope?.Body?.AddWiFiSettings_OUTPUT?.ReturnValue === 0
+            ? addUnique(context.profilesAdded, context.wifiProfileName)
+            : context.profilesAdded,
+        profilesFailed: ({ context, event }) =>
+          event.output.Envelope?.Body?.AddWiFiSettings_OUTPUT?.ReturnValue === 0
+            ? removeItem(context.profilesFailed, context.wifiProfileName)
+            : addFailure(context.profilesFailed, context.profilesAdded, context.wifiProfileName)
       })
     }
   }).createMachine({
@@ -392,7 +379,7 @@ export class WiFiConfiguration {
         on: {
           WIFICONFIG: {
             actions: [
-              assign({ wifiProfileCount: () => 0 }),
+              assign({ wifiProfileCount: () => 0, profilesAdded: () => undefined, profilesFailed: () => undefined }),
               'Reset Unauth Count',
               'Reset Retry Count'
             ],
@@ -696,9 +683,7 @@ export class WiFiConfiguration {
           onError: {
             actions: assign({
               profilesFailed: ({ context }) =>
-                context.profilesFailed == null
-                  ? `${context.wifiProfileName}`
-                  : `${context.profilesFailed}, ${context.wifiProfileName}`
+                addFailure(context.profilesFailed, context.profilesAdded, context.wifiProfileName)
             }),
             target: 'CHECK_ADD_WIFI_SETTINGS_RESPONSE'
           }

--- a/src/utils/statusList.test.ts
+++ b/src/utils/statusList.test.ts
@@ -1,0 +1,50 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { addUnique, removeItem, addFailure } from './statusList.js'
+
+describe('statusList', () => {
+  describe('addUnique', () => {
+    it('appends to an empty list', () => {
+      expect(addUnique(undefined, 'P1')).toEqual('P1')
+    })
+    it('appends a new item', () => {
+      expect(addUnique('P1', 'P2')).toEqual('P1, P2')
+    })
+    it('does not append a duplicate', () => {
+      expect(addUnique('P1, P2', 'P2')).toEqual('P1, P2')
+    })
+    it('ignores empty/null names', () => {
+      expect(addUnique('P1', '')).toEqual('P1')
+      expect(addUnique('P1', null)).toEqual('P1')
+    })
+  })
+
+  describe('removeItem', () => {
+    it('removes an item', () => {
+      expect(removeItem('P1, P2, P3', 'P2')).toEqual('P1, P3')
+    })
+    it('returns undefined when the list becomes empty', () => {
+      expect(removeItem('P1', 'P1')).toBeUndefined()
+    })
+    it('is a no-op when the item is absent or list is empty', () => {
+      expect(removeItem('P1, P2', 'P9')).toEqual('P1, P2')
+      expect(removeItem(undefined, 'P1')).toBeUndefined()
+    })
+  })
+
+  describe('addFailure', () => {
+    it('appends a genuinely failed item', () => {
+      expect(addFailure('P5', undefined, 'P6')).toEqual('P5, P6')
+    })
+    it('does not mark a failure for an item that already succeeded', () => {
+      expect(addFailure(undefined, 'P1, P2', 'P1')).toBeUndefined()
+      expect(addFailure('P5', 'P1, P2', 'P2')).toEqual('P5')
+    })
+    it('deduplicates repeated failures', () => {
+      expect(addFailure('P5', undefined, 'P5')).toEqual('P5')
+    })
+  })
+})

--- a/src/utils/statusList.ts
+++ b/src/utils/statusList.ts
@@ -1,0 +1,44 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Helpers for the comma-separated "added"/"failed" item accumulators used by the wifi and proxy
+// state machines. They keep the lists deduplicated and mutually exclusive so a re-attempt (e.g.
+// "already exists") can't list the same item as both added and failed, or list it twice.
+
+const split = (list?: string | null): string[] => (list ? list.split(', ').filter((s) => s.length > 0) : [])
+
+/** Appends name to a comma-separated list, skipping empty names and duplicates. */
+export function addUnique(list: string | undefined, name?: string | null): string | undefined {
+  if (name == null || name === '') {
+    return list
+  }
+  const items = split(list)
+  if (items.includes(name)) {
+    return list
+  }
+  items.push(name)
+  return items.join(', ')
+}
+
+/** Removes name from a comma-separated list, returning undefined when the list becomes empty. */
+export function removeItem(list: string | undefined, name?: string | null): string | undefined {
+  if (name == null || name === '' || list == null) {
+    return list
+  }
+  const items = split(list).filter((n) => n !== name)
+  return items.length > 0 ? items.join(', ') : undefined
+}
+
+/** Records a failed item, but not if it already succeeded (present in `added`); deduplicated. */
+export function addFailure(
+  failed: string | undefined,
+  added: string | undefined,
+  name?: string | null
+): string | undefined {
+  if (name == null || name === '' || split(added).includes(name)) {
+    return failed
+  }
+  return addUnique(failed, name)
+}


### PR DESCRIPTION
The wifi and proxy machines append profile/proxy names to comma- separated added/failed accumulators at two sites each, with no dedup, no removal when an item later succeeds, and no reset on re-entry (ACTIVATION clears the counter but not the lists). A re-attempted item (e.g. 'already exists') could therefore appear in both lists and be listed multiple times, e.g. 'Added P1,P2 ... Failed to add P1,P2,P5,P5'.

Add a small statusList util (addUnique/removeItem/addFailure) and use it so the lists stay deduplicated and mutually exclusive, and reset the accumulators alongside the counter on (re)entry.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
