### PR TITLE
fix(db): dedupe profile wifi/proxy configs in Cartesian-product join

### DIFF
--- a/src/data/postgres/tables/profiles.test.ts
+++ b/src/data/postgres/tables/profiles.test.ts
@@ -128,11 +128,11 @@ describe('profiles tests', () => {
       tls_signing_authority as "tlsSigningAuthority",
       p.xmin as "version",
       ieee8021x_profile_name as "ieee8021xProfileName",
-      COALESCE(json_agg(json_build_object('profileName',wc.wireless_profile_name, 'priority', wc.priority)) FILTER (WHERE wc.wireless_profile_name IS NOT NULL), '[]') AS "wifiConfigs",
+      COALESCE(jsonb_agg(DISTINCT jsonb_build_object('profileName',wc.wireless_profile_name, 'priority', wc.priority)) FILTER (WHERE wc.wireless_profile_name IS NOT NULL), '[]'::jsonb) AS "wifiConfigs",
       ip_sync_enabled as "ipSyncEnabled",
       local_wifi_sync_enabled as "localWifiSyncEnabled",
       uefi_wifi_sync_enabled as "uefiWifiSyncEnabled",
-      COALESCE(json_agg(json_build_object('name',pc.proxy_config_name, 'priority', pc.priority)) FILTER (WHERE pc.proxy_config_name IS NOT NULL), '[]') AS "proxyConfigs"
+      COALESCE(jsonb_agg(DISTINCT jsonb_build_object('name',pc.proxy_config_name, 'priority', pc.priority)) FILTER (WHERE pc.proxy_config_name IS NOT NULL), '[]'::jsonb) AS "proxyConfigs"
     FROM profiles p
     LEFT JOIN profiles_wirelessconfigs wc ON wc.profile_name = p.profile_name AND wc.tenant_id = p.tenant_id
     LEFT JOIN profiles_proxyconfigs pc ON pc.profile_name = p.profile_name AND pc.tenant_id = p.tenant_id
@@ -189,11 +189,11 @@ describe('profiles tests', () => {
       tls_signing_authority as "tlsSigningAuthority",
       p.xmin as "version",
       ieee8021x_profile_name as "ieee8021xProfileName",
-      COALESCE(json_agg(json_build_object('profileName',wc.wireless_profile_name, 'priority', wc.priority)) FILTER (WHERE wc.wireless_profile_name IS NOT NULL), '[]') AS "wifiConfigs",
+      COALESCE(jsonb_agg(DISTINCT jsonb_build_object('profileName',wc.wireless_profile_name, 'priority', wc.priority)) FILTER (WHERE wc.wireless_profile_name IS NOT NULL), '[]'::jsonb) AS "wifiConfigs",
       ip_sync_enabled as "ipSyncEnabled",
       local_wifi_sync_enabled as "localWifiSyncEnabled",
       uefi_wifi_sync_enabled as "uefiWifiSyncEnabled",
-      COALESCE(json_agg(json_build_object('name',pc.proxy_config_name, 'priority', pc.priority)) FILTER (WHERE pc.proxy_config_name IS NOT NULL), '[]') AS "proxyConfigs"
+      COALESCE(jsonb_agg(DISTINCT jsonb_build_object('name',pc.proxy_config_name, 'priority', pc.priority)) FILTER (WHERE pc.proxy_config_name IS NOT NULL), '[]'::jsonb) AS "proxyConfigs"
     FROM profiles p
     LEFT JOIN profiles_wirelessconfigs wc ON wc.profile_name = p.profile_name AND wc.tenant_id = p.tenant_id
     LEFT JOIN profiles_proxyconfigs pc ON pc.profile_name = p.profile_name AND pc.tenant_id = p.tenant_id

--- a/src/data/postgres/tables/profiles.ts
+++ b/src/data/postgres/tables/profiles.ts
@@ -76,11 +76,11 @@ export class ProfilesTable implements IProfilesTable {
       tls_signing_authority as "tlsSigningAuthority",
       p.xmin as "version",
       ieee8021x_profile_name as "ieee8021xProfileName",
-      COALESCE(json_agg(json_build_object('profileName',wc.wireless_profile_name, 'priority', wc.priority)) FILTER (WHERE wc.wireless_profile_name IS NOT NULL), '[]') AS "wifiConfigs",
+      COALESCE(jsonb_agg(DISTINCT jsonb_build_object('profileName',wc.wireless_profile_name, 'priority', wc.priority)) FILTER (WHERE wc.wireless_profile_name IS NOT NULL), '[]'::jsonb) AS "wifiConfigs",
       ip_sync_enabled as "ipSyncEnabled",
       local_wifi_sync_enabled as "localWifiSyncEnabled",
       uefi_wifi_sync_enabled as "uefiWifiSyncEnabled",
-      COALESCE(json_agg(json_build_object('name',pc.proxy_config_name, 'priority', pc.priority)) FILTER (WHERE pc.proxy_config_name IS NOT NULL), '[]') AS "proxyConfigs"
+      COALESCE(jsonb_agg(DISTINCT jsonb_build_object('name',pc.proxy_config_name, 'priority', pc.priority)) FILTER (WHERE pc.proxy_config_name IS NOT NULL), '[]'::jsonb) AS "proxyConfigs"
     FROM profiles p
     LEFT JOIN profiles_wirelessconfigs wc ON wc.profile_name = p.profile_name AND wc.tenant_id = p.tenant_id
     LEFT JOIN profiles_proxyconfigs pc ON pc.profile_name = p.profile_name AND pc.tenant_id = p.tenant_id
@@ -141,11 +141,11 @@ export class ProfilesTable implements IProfilesTable {
       tls_signing_authority as "tlsSigningAuthority",
       p.xmin as "version",
       ieee8021x_profile_name as "ieee8021xProfileName",
-      COALESCE(json_agg(json_build_object('profileName',wc.wireless_profile_name, 'priority', wc.priority)) FILTER (WHERE wc.wireless_profile_name IS NOT NULL), '[]') AS "wifiConfigs",
+      COALESCE(jsonb_agg(DISTINCT jsonb_build_object('profileName',wc.wireless_profile_name, 'priority', wc.priority)) FILTER (WHERE wc.wireless_profile_name IS NOT NULL), '[]'::jsonb) AS "wifiConfigs",
       ip_sync_enabled as "ipSyncEnabled",
       local_wifi_sync_enabled as "localWifiSyncEnabled",
       uefi_wifi_sync_enabled as "uefiWifiSyncEnabled",
-      COALESCE(json_agg(json_build_object('name',pc.proxy_config_name, 'priority', pc.priority)) FILTER (WHERE pc.proxy_config_name IS NOT NULL), '[]') AS "proxyConfigs"
+      COALESCE(jsonb_agg(DISTINCT jsonb_build_object('name',pc.proxy_config_name, 'priority', pc.priority)) FILTER (WHERE pc.proxy_config_name IS NOT NULL), '[]'::jsonb) AS "proxyConfigs"
     FROM profiles p
     LEFT JOIN profiles_wirelessconfigs wc ON wc.profile_name = p.profile_name AND wc.tenant_id = p.tenant_id
     LEFT JOIN profiles_proxyconfigs pc ON pc.profile_name = p.profile_name AND pc.tenant_id = p.tenant_id


### PR DESCRIPTION
The profile queries LEFT JOIN both profiles_wirelessconfigs and profiles_proxyconfigs and aggregate with json_agg. With both lists populated the joins form a Cartesian product, so each wifi config was duplicated (# proxy configs) times and vice versa -- causing every wifi profile to be added twice (add succeeds, re-add fails 'already exists').

Use jsonb_agg(DISTINCT ...) so the aggregated lists are deduplicated.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
