### PR TITLE
build(deps): bump github/codeql-action from 4.36.2 to 4.36.3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,7 +55,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.29.5
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3.29.5
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -66,7 +66,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.29.5
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3.29.5
         # ℹ️ Command-line programs to run using the OS shell.
         # 📚 https://git.io/JvXDl
 
@@ -79,7 +79,7 @@ jobs:
         #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.29.5
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3.29.5
       - name: Generate Security Report
         uses: rsdmike/github-security-report-action@a149b24539044c92786ec39af8ba38c93496495d # v3.0.4
         continue-on-error: true


### PR DESCRIPTION
Bumps the `github/codeql-action` steps (`init`, `autobuild`, `analyze`) in `.github/workflows/codeql-analysis.yml` from `8aad20d` (v3.29.5, 4.36.2) to `54f647b` (v3.29.5, 4.36.3).

Consolidates the three dependabot PRs into a single PR:
- Closes #2790 (init)
- Closes #2792 (autobuild)
- Closes #2797 (analyze)

🤖 Generated with [Claude Code](https://claude.com/claude-code)