### PR TITLE
ci(docker): align builder base image with node lts-bullseye-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) Intel Corporation 2021
 # SPDX-License-Identifier: Apache-2.0
 #*********************************************************************/
-FROM node:25-bullseye-slim@sha256:7ec50c1867732dc73facf8b318e029764dab970271691b06cd6895975c1a038e as builder
+FROM node:lts-bullseye-slim@sha256:aca89821b1f09df223227ff2abe075fc3161f05604d3b61309f46820a5938020 as builder
 
 WORKDIR /rps
 


### PR DESCRIPTION
The builder stage pinned node:25-bullseye-slim. Node 25 is an odd-numbered release that reached end-of-life on 2026-06-01 and no longer receives security patches, so the pinned digest was stale.

The runtime stage installs Node via `apk add nodejs`, which on Alpine 3.24 resolves to 24.17.0 -- images were therefore compiled on one major and executed on another. Repin the builder to node:lts-bullseye-slim (currently Node 24, Active LTS through 2028-04-30).

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
