### PR TITLE
ci(gh-actions): drop redundant image build in api tests

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - run: docker build -f Dockerfile -t rps:${GITHUB_SHA} .
       - run: docker compose up -d
 
       - name: Let Docker Spin up


### PR DESCRIPTION
docker-compose.yml declares a build block for the rps service and tags the result `rps:latest`, but the preceding step tagged the image `rps:${GITHUB_SHA}`, which compose never references. The Dockerfile was therefore built twice and the sha-tagged image discarded unused; nothing in this workflow pushes or otherwise consumes that tag.

Letting compose perform the single build also means the container under test is the one built from the checked-out source.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
